### PR TITLE
Changed encounter_datetime to test_datetime as underlying dataset had…

### DIFF
--- a/dao/patient/etl-patient-dao.js
+++ b/dao/patient/etl-patient-dao.js
@@ -65,7 +65,7 @@ module.exports = function() {
         table: "etl.flat_labs_and_imaging",
         where: ["uuid = ?", uuid],
         order: order || [{
-          column: 'encounter_datetime',
+          column: 'test_datetime',
           asc: false
         }],
         offset: request.query.startIndex,


### PR DESCRIPTION
… changed.

The flat_labs_and_imaging dataset previously had a column called encounter_datetime which is now called test_datetime. 