### PR TITLE
NGPOC-436 : Modify ETL end-point for fetching a day's has-not-returne…

### DIFF
--- a/dao/analytics/etl-analytics-dao.js
+++ b/dao/analytics/etl-analytics-dao.js
@@ -50,8 +50,10 @@ module.exports = function () {
             });
         },
         runReport: function runReport(reportParams) {
+            console.log('Report Params', reportParams);
             //build report
             var queryParts = reportFactory.singleReportToSql(reportParams);
+            console.log('Query Parts', queryParts);
             return new Promise(function (resolve, reject) {
                 db.reportQueryServer(queryParts, function (results) {
                     if (results.error) {
@@ -268,6 +270,7 @@ module.exports = function () {
         getIdsByUuidAsyc: function getIdsByUuidAsyc(fullTableName, idColumnName, uuidColumnName, arrayOfUuids, callback) {
             var uuids = [];
             _.each(arrayOfUuids.split(','), function (uuid) {
+                console.log('Uuid', uuid);
                 uuids.push(uuid);
             });
 

--- a/etl-factory.js
+++ b/etl-factory.js
@@ -72,7 +72,7 @@ module.exports = function () {
 
     }
     function getExpression(){
-        var expression =s.replaceAll(filterOption.expression,filterOption.options,);
+        var expression =s.replaceAll(filterOption.expression,filterOption.options);
         _.each(report.disintegrationFilterOptions, function (filterOption) {
 
         });
@@ -187,16 +187,19 @@ module.exports = function () {
     }
 
     function _buildQueryParts(requestParams, reportName, queryPartsArray) {
+        console.log('Build Query Parts Request Params',requestParams );
         if (reportName) {
             reportName = reportName;
         } else {
             reportName = requestParams.reportName;
         }
+
         var queryParts;
         _.each(reports, function (report) {
 
             if (report.name === reportName) {
                 var nestedParts = '';
+                var tableName  = '';
                 if (report.table.dynamicDataset && report.table.dynamicDataset !== reportName) {
                     _buildQueryParts(requestParams, report.table.dynamicDataset, queryPartsArray);
                     //get the last item of the array
@@ -207,10 +210,18 @@ module.exports = function () {
                 } else {
                     nestedParts = undefined;
                 }
+
+                if(report.table['tableName'] === '@tableName'){
+                     tableName = requestParams.tableName;
+                     console.log('Empty Table Name', requestParams.tableName );
+                } else{
+                     tableName = report.table['tableName'];
+                }
+                console.log('Table Name', tableName);
                 var queryParts = {
                     columns: indicatorsToColumns(report, requestParams.countBy, requestParams),
                     concatColumns: concatColumnsToColumns(report),
-                    table: report.table['schema'] + '.' + report.table['tableName'],
+                    table: report.table['schema'] + '.' + tableName,
                     alias: report.table['alias'],
                     indexExpression: report.table['indexExpression'] || null,
                     nestedParts: nestedParts,

--- a/pre-request-processing.js
+++ b/pre-request-processing.js
@@ -30,3 +30,4 @@ function resolveLocationIdsToLocationUuids(request, callback) {
             }).onResolved = onResolvedPromise;
     }
 }
+

--- a/programs/program-visits-config.json
+++ b/programs/program-visits-config.json
@@ -8,8 +8,9 @@
     ],
     "visitTypes": [
       {
-        "uuid": "d9eedf86-a623-46c2-9e89-a3d477f0253b",
+        "uuid": "33d13ffb-5f0e-427e-ab80-637491fb6526",
         "name": "Adult HIV Initial Visit ",
+        "allowedIf": "age >= 20 && programLocation === intendedVisitLocationUuid && isFirstAMPATHHIVVisit",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
@@ -26,26 +27,24 @@
         ]
       },
       {
-        "uuid": "31263661-f061-4b11-ab8f-e8e9ce01d086",
+        "uuid": "0ae56e8a-93ed-4071-82f1-0eaf3eb592ff",
         "name": "Adult Transfer In Visit ",
+        "allowedIf": "age >= 20 && programLocation === intendedVisitLocationUuid && !isFirstAMPATHHIVVisit && previousHIVClinicallocation !== programLocation",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
             "display": "HIVTRIAGE"
           },
           {
-            "uuid": "cbe2d31d-2201-44ce-b52e-fbd5dc7cff33",
-            "display": "TRANSFERENCOUNTER"
-          },
-          {
-            "uuid": "*?????????????AdultTransferIn??????????",
-            "display": "AdultTransferIn"
+            "uuid": "61aaec4d-231e-4cdf-9116-1862752dcb9a",
+            "display": "ADULTRANSFERIN"
           }
         ]
       },
       {
-        "uuid": "1d8afe47-c4f5-4828-b906-91edc5247018",
+        "uuid": "d4ac2aa5-2899-42fb-b08a-d40161815b48",
         "name": "Adult HIV Return Visit ",
+        "allowedIf": "age >= 20 && programLocation === intendedVisitLocationUuid && !isFirstAMPATHHIVVisit",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
@@ -62,9 +61,9 @@
         ]
       },
       {
-        "uuid": "09e95f36-13ad-4cec-bbe7-5daa9e68727a",
+        "uuid": "18faa058-4eea-4339-a959-84b3e5cb30be",
         "name": "Pediatric HIV Initial Visit ",
-        "allowedIf": "age >= 20 && previousHIVClinicallocation !== intendedVisitLocationUuid && isFirstAMPATHHIVVisit",
+        "allowedIf": "age <= 14 && programLocation === intendedVisitLocationUuid && isFirstAMPATHHIVVisit",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
@@ -81,8 +80,9 @@
         ]
       },
       {
-        "uuid": "d9b45f77-93e9-4f03-b2f7-3179a7eaa6f0",
+        "uuid": "2e67b87c-8843-45b7-a380-3a0e8bd58e4d",
         "name": "Pediatric Transfer In Visit ",
+        "allowedIf": "age <= 14 && programLocation === intendedVisitLocationUuid && !isFirstAMPATHHIVVisit && previousHIVClinicallocation !== programLocation",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
@@ -93,14 +93,15 @@
             "display": "TRANSFERENCOUNTER"
           },
           {
-            "uuid": "*??????????????????????????PedsTransferIn?????????????",
-            "display": "PedsTransferIn"
+            "uuid": "f6257ec8-706d-4342-ada4-ddc2f6478470",
+            "display": "PEDSTRANSFERIN"
           }
         ]
       },
       {
-        "uuid": "5cd33873-64ac-4681-98ca-3d79a3e9dbed",
+        "uuid": "edb7c6aa-fc69-4470-936d-3d484d3708aa",
         "name": "Pediatric HIV Return Visit ",
+        "allowedIf": "age <= 14 && programLocation === intendedVisitLocationUuid && !isFirstAMPATHHIVVisit",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
@@ -117,8 +118,9 @@
         ]
       },
       {
-        "uuid": "e84622c1-7fe8-425d-a4d4-d6740289855e",
+        "uuid": "03f5b165-c577-4e1e-b7ae-acfc3ba18ebf",
         "name": "Youth HIV Initial Visit ",
+        "allowedIf": "age >= 10 && age <= 20 && programLocation === intendedVisitLocationUuid && isFirstAMPATHHIVVisit",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
@@ -135,8 +137,9 @@
         ]
       },
       {
-        "uuid": "9adb4697-3667-4d72-b2ab-bd9033818ff6",
+        "uuid": "b27e13f7-7118-4c0d-b9d6-b759495991d6",
         "name": "Youth Transfer In Visit ",
+        "allowedIf": "age >= 10 && age <= 20 && programLocation === intendedVisitLocationUuid && !isFirstAMPATHHIVVisit && previousHIVClinicallocation !== programLocation",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
@@ -147,14 +150,15 @@
             "display": "TRANSFERENCOUNTER"
           },
           {
-            "uuid": "*????????????YouthTransferIn??????????",
-            "display": "YouthTransferIn"
+            "uuid": "a0c2fe63-7be4-4067-87cc-a8654deb552e",
+            "display": "YOUTHTRANSFERIN"
           }
         ]
       },
       {
-        "uuid": "4c84516f-279e-4994-b111-84d4d35a2d97",
+        "uuid": "824cf3e6-dd16-4767-ba41-2e04dede349e",
         "name": "Youth HIV Return Visit ",
+        "allowedIf": "age >= 10 && age <= 20 && programLocation === intendedVisitLocationUuid && !isFirstAMPATHHIVVisit",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
@@ -171,61 +175,7 @@
         ]
       },
       {
-        "uuid": "410c1874-65eb-4def-9a53-c09823b764e4",
-        "name": "Differentiated Care Clinical Visit ",
-        "encounterTypes": [
-          {
-            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
-            "display": "HIVTRIAGE"
-          },
-          {
-            "uuid": "cbe2d31d-2201-44ce-b52e-fbd5dc7cff33",
-            "display": "TRANSFERENCOUNTER"
-          },
-          {
-            "uuid": "e3202a01-8cd5-4224-b0dd-760557f85310",
-            "display": "DIFFERENTIATEDCARE"
-          }
-        ]
-      },
-      {
-        "uuid": "b9b75f23-7fcc-492f-9a44-5544590c4760",
-        "name": "Differentiated Care Pharmacy Visit ",
-        "encounterTypes": [
-          {
-            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
-            "display": "HIVTRIAGE"
-          },
-          {
-            "uuid": "cbe2d31d-2201-44ce-b52e-fbd5dc7cff33",
-            "display": "TRANSFERENCOUNTER"
-          },
-          {
-            "uuid": "e3202a01-8cd5-4224-b0dd-760557f85310",
-            "display": "DIFFERENTIATEDCARE"
-          }
-        ]
-      },
-      {
-        "uuid": "d1b92b20-c087-4036-8a61-54d978316fe9",
-        "name": "Express Care Visit ",
-        "encounterTypes": [
-          {
-            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
-            "display": "HIVTRIAGE"
-          },
-          {
-            "uuid": "cbe2d31d-2201-44ce-b52e-fbd5dc7cff33",
-            "display": "TRANSFERENCOUNTER"
-          },
-          {
-            "uuid": "df554398-1350-11df-a1f1-0026b9348838",
-            "display": "ECSTABLE"
-          }
-        ]
-      },
-      {
-        "uuid": "a21e0f58-adb0-4a88-8877-b1a8af9c5cab",
+        "uuid": "dcdefd27-82b9-48e3-821b-3ffc6463564e",
         "name": "Resistance Clinic Visit ",
         "encounterTypes": [
           {
@@ -243,69 +193,62 @@
         ]
       },
       {
-        "uuid": "1c9ec4a1-5383-4f92-b972-ada376256cf7",
+        "uuid": "43ec2bb7-ec8e-4a66-a29d-db6281399ea5",
         "name": "Between Care Visit ",
+        "allowedIf": "programLocation !== intendedVisitLocationUuid && !isFirstAMPATHHIVVisit",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
             "display": "HIVTRIAGE"
           },
           {
-            "uuid": "*??????????????????Between-Care-Visit?????????????",
-            "display": "Between-Care-Visit"
+            "uuid": "db9f6a5c-e141-49fc-ad2b-bdce3f9a6c80",
+            "display": "BETWEENCAREVISIT"
           }
         ]
       },
       {
-        "uuid": "1782fc7b-acfb-4820-b5a6-98188d7a9c17",
-        "name": "Transit Care Visit ",
-        "encounterTypes": [
-          {
-            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
-            "display": "HIVTRIAGE"
-          },
-          {
-            "uuid": "*??????????????????transit-Visit?????????????",
-            "display": "transit-Visit"
-          }
-        ]
-      },
-      {
-        "uuid": "dd577eb9-03ed-4bc1-a784-0c0bd9affca5",
-        "name": "Inpatient Peer Visit ",
+        "uuid": "260c2535-f946-44ea-a038-34cc4f8174be",
+        "name": "Outreach Visit ",
         "encounterTypes": [
           {
             "uuid": "10a86a62-b771-44d1-b1ad-3b8496c7bc47",
             "display": "INPATIENTPEER"
+          },
+          {
+            "uuid": "df5547bc-1350-11df-a1f1-0026b9348838",
+            "display": "OUTREACHFIELDFU"
           }
         ]
       },
       {
-        "uuid": "3d2f6f84-0a0b-47c3-b209-ba26d2accd18",
-        "name": "MDT Visit ",
+        "uuid": "6c5d74f4-943f-489a-b1c4-b2accfae92fb",
+        "name": "MDT Visit",
+        "allowedIf": "age >= 20 && programLocation === intendedVisitLocationUuid",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
             "display": "HIVTRIAGE"
-          },
-          {
-            "uuid": "8d5b3108-c2cc-11de-8d13-0010c6dffd0f",
-            "display": "PEDSRETURN"
-          },
-          {
-            "uuid": "4e7553b4-373d-452f-bc89-3f4ad9a01ce7",
-            "display": "YOUTHRETURN"
           },
           {
             "uuid": "8d5b2be0-c2cc-11de-8d13-0010c6dffd0f",
             "display": "ADULTRETURN"
           },
           {
-            "uuid": "*??????????????????MDT-Form?????????????",
-            "display": "MDT-Form"
+            "uuid": "4e7553b4-373d-452f-bc89-3f4ad9a01ce7",
+            "display": "YOUTHRETURN"
+          },
+          {
+            "uuid": "8d5b3108-c2cc-11de-8d13-0010c6dffd0f",
+            "display": "PEDSRETURN"
+          },
+          {
+            "uuid": "3c8cd5d4-cdc2-4136-8326-224b682b6543",
+            "display": "MDTFORM"
           }
         ]
       }
+
     ]
   },
   "725b5193-3452-43fc-aca3-6a80432d9bfa": {
@@ -315,109 +258,7 @@
       "enrollment",
       "hivLastTenClinicalEncounters"
     ],
-    "visitTypes": [
-      {
-        "uuid": "d16a87ae-470f-4cea-a849-242b15b46934",
-        "name": "Breast Cancer Screening ",
-        "encounterTypes": [
-          {
-            "uuid": "fc08ae1c-4588-443b-ae46-856bb20a5ee9",
-            "display": "OncologyDiagnosisChange"
-          },
-          {
-            "uuid": "9bc0fa73-474e-45ab-bdac-7282e95d856f",
-            "display": "ONCOLOGYDYSPLASIA"
-          },
-          {
-            "uuid": "d17b3adc-0837-4ac6-862b-0953fc664cb8",
-            "display": "OncologyInitial "
-          },
-          {
-            "uuid": "c7fd9ee7-c376-436d-a252-01e89cc51112",
-            "display": "OncologyLabandChemoTracking "
-          },
-          {
-            "uuid": "eeb9600c-314f-4071-9122-133ff3da37bb",
-            "display": "OncologyReturn"
-          },
-          {
-            "uuid": "49bd34db-39e8-4b70-bbba-676ccaf9fdd3",
-            "display": "OncologyReturnWithNewDiagnosticInfo"
-          },
-          {
-            "uuid": "f8e35989-74b7-4a18-87ac-31e98b8d9004",
-            "display": "ONCOLOGYTRIAGE"
-          },
-          {
-            "uuid": "238625fc-8a25-44b2-aa5a-8bf48fa0e18d",
-            "display": "ONCOLOGYVIA"
-          }
-        ]
-      },
-      {
-        "uuid": "0ba3f08e-9335-4132-9aaa-67451df31775",
-        "name": "Cervical Cancer Screening ",
-        "encounterTypes": [
-          {
-            "uuid": "fc08ae1c-4588-443b-ae46-856bb20a5ee9",
-            "display": "OncologyDiagnosisChange"
-          },
-          {
-            "uuid": "9bc0fa73-474e-45ab-bdac-7282e95d856f",
-            "display": "ONCOLOGYDYSPLASIA"
-          },
-          {
-            "uuid": "d17b3adc-0837-4ac6-862b-0953fc664cb8",
-            "display": "OncologyInitial "
-          },
-          {
-            "uuid": "c7fd9ee7-c376-436d-a252-01e89cc51112",
-            "display": "OncologyLabandChemoTracking "
-          },
-          {
-            "uuid": "eeb9600c-314f-4071-9122-133ff3da37bb",
-            "display": "OncologyReturn"
-          },
-          {
-            "uuid": "49bd34db-39e8-4b70-bbba-676ccaf9fdd3",
-            "display": "OncologyReturnWithNewDiagnosticInfo"
-          },
-          {
-            "uuid": "f8e35989-74b7-4a18-87ac-31e98b8d9004",
-            "display": "ONCOLOGYTRIAGE"
-          },
-          {
-            "uuid": "238625fc-8a25-44b2-aa5a-8bf48fa0e18d",
-            "display": "ONCOLOGYVIA"
-          }
-        ]
-      },
-      {
-        "uuid": "ac3914d2-ea15-46be-ba6a-06ae6cc2010c",
-        "name": "Cervical Cancer Treatment ",
-        "encounterTypes": []
-      },
-      {
-        "uuid": "32443ed6-9b77-4644-9dce-e1adfd5be843",
-        "name": "Breast Cancer Treatment ",
-        "encounterTypes": []
-      },
-      {
-        "uuid": "cd891907-5ea6-457d-af6d-1cd78865fb3c",
-        "name": "Sickle cell ",
-        "encounterTypes": []
-      },
-      {
-        "uuid": "0754d17f-3b37-4391-92c0-5dba87c9e5f2",
-        "name": "Multiple Myeloma ",
-        "encounterTypes": []
-      },
-      {
-        "uuid": "f2f0795e-de80-4320-815a-6e37ac8c35ed",
-        "name": "Hemophilia ",
-        "encounterTypes": []
-      }
-    ]
+    "visitTypes": []
   },
   "fc15ac01-5381-4854-bf5e-917c907aa77f": {
     "name": "CDM PROGRAM",
@@ -428,7 +269,7 @@
     ],
     "visitTypes": [
       {
-        "uuid": "2b918f1a-2494-4693-993b-91d6f6ed8efc",
+        "uuid": "8072afd0-0cd9-409e-914d-1833e83943f7",
         "name": "CDM Visit",
         "encounterTypes": []
       }
@@ -443,12 +284,17 @@
     ],
     "visitTypes": [
       {
-        "uuid": "70134106-68f6-47e5-9ee0-3a9448f5f380",
+        "uuid": "45b55bfd-84f5-4783-b7fb-ac4d82832c24",
+        "allowedIf": "programLocation === intendedVisitLocationUuid",
         "name": "PMTCT Visit ",
         "encounterTypes": [
           {
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
             "display": "HIVTRIAGE"
+          },
+          {
+            "uuid": "cbe2d31d-2201-44ce-b52e-fbd5dc7cff33",
+            "display": "TRANSFERENCOUNTER"
           },
           {
             "uuid": "7bf4632a-00e8-4c0a-a296-c3977fdd6671",
@@ -488,8 +334,8 @@
     ],
     "visitTypes": []
   },
-  "pep-visit-types": {
-    "name": "BSG PROGRAM",
+  "96047aaf-7ab3-45e9-be6a-b61810fe617d": {
+    "name": "PEP PROGRAM",
     "dataDependencies": [
       "patient",
       "enrollment",
@@ -497,7 +343,7 @@
     ],
     "visitTypes": [
       {
-        "uuid": "ffb14518-f012-4c01-99c1-2f5a6efb7025",
+        "uuid": "58f20c53-aac7-4e73-bd7a-97986435e570",
         "name": "PEP Visit ",
         "encounterTypes": [
           {
@@ -513,9 +359,19 @@
             "display": "PEPRETURN"
           }
         ]
-      },
+      }
+    ]
+  },
+  "c19aec66-1a40-4588-9b03-b6be55a8dd1d": {
+    "name": "PrEP PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
       {
-        "uuid": "4d4fac46-5bc5-4b63-a69b-328532d1a2da",
+        "uuid": "330d9739-833d-48a8-8986-f1069c320194",
         "name": "PrEP Visit ",
         "encounterTypes": [
           {
@@ -523,15 +379,361 @@
             "display": "HIVTRIAGE"
           },
           {
-            "uuid": "*?????????????????????????prep-initial?????????????????????????",
-            "display": "prep-initial"
+            "uuid": "00ee2fd6-9c95-4ffc-ab31-6b1ce2dede4d",
+            "display": "PREPINITIAL"
           },
           {
-            "uuid": "prep-return",
-            "display": "*?????????????????????????prep-return?????????????????????????"
+            "uuid": "ddd96f1c-524f-4caa-81a6-1a6f9789a4bc",
+            "display": "PREPRETURN"
           }
         ]
       }
+    ]
+  },
+  "334c9e98-173f-4454-a8ce-f80b20b7fdf0": {
+    "name": "HIV DIFFERENTIATED CARE PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+      {
+        "uuid": "9bf3fadd-4938-40fa-a093-4e01bf197876",
+        "name": "Differentiated Care Clinical Visit ",
+        "allowedIf": "programLocation === intendedVisitLocationUuid",
+        "encounterTypes": [
+          {
+            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
+            "display": "HIVTRIAGE"
+          },
+          {
+            "uuid": "cbe2d31d-2201-44ce-b52e-fbd5dc7cff33",
+            "display": "TRANSFERENCOUNTER"
+          },
+          {
+            "uuid": "e3202a01-8cd5-4224-b0dd-760557f85310",
+            "display": "DIFFERENTIATEDCARE"
+          }
+        ]
+      },
+      {
+        "uuid": "6bf34991-7414-4b5e-ad75-ca217d4c4939",
+        "name": "Differentiated Care Pharmacy Visit ",
+        "encounterTypes": [
+          {
+            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
+            "display": "HIVTRIAGE"
+          },
+          {
+            "uuid": "cbe2d31d-2201-44ce-b52e-fbd5dc7cff33",
+            "display": "TRANSFERENCOUNTER"
+          },
+          {
+            "uuid": "e3202a01-8cd5-4224-b0dd-760557f85310",
+            "display": "DIFFERENTIATEDCARE"
+          }
+        ]
+      }
+    ]
+  },
+  "96ba279b-b23b-4e78-aba9-dcbd46a96b7b": {
+    "name": "HIV TRANSIT PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+      {
+        "uuid": "52e67f49-4ec3-41b2-bfe2-93144ea03eb2",
+        "name": "Transit Care Visit ",
+        "encounterTypes": [
+          {
+            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
+            "display": "HIVTRIAGE"
+          },
+          {
+            "uuid": "704abe82-d00f-4fd3-a5fd-616c53d78b48",
+            "display": "TRANSITVISIT"
+          }
+        ]
+      }
+
+    ]
+  },
+  "142939b0-28a9-4649-baf9-a9d012bf3b3d": {
+    "name": "BREAST CANCER SCREENING PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+
+      {
+        "uuid": "55d8d186-3f74-43ad-9e40-eb16bb52b596",
+        "name": "Breast Cancer Screening ",
+        "encounterTypes": [
+          {
+            "uuid": "fc08ae1c-4588-443b-ae46-856bb20a5ee9",
+            "display": "OncologyDiagnosisChange"
+          },
+          {
+            "uuid": "9bc0fa73-474e-45ab-bdac-7282e95d856f",
+            "display": "ONCOLOGYDYSPLASIA"
+          },
+          {
+            "uuid": "d17b3adc-0837-4ac6-862b-0953fc664cb8",
+            "display": "OncologyInitial "
+          },
+          {
+            "uuid": "c7fd9ee7-c376-436d-a252-01e89cc51112",
+            "display": "OncologyLabandChemoTracking "
+          },
+          {
+            "uuid": "eeb9600c-314f-4071-9122-133ff3da37bb",
+            "display": "OncologyReturn"
+          },
+          {
+            "uuid": "49bd34db-39e8-4b70-bbba-676ccaf9fdd3",
+            "display": "OncologyReturnWithNewDiagnosticInfo"
+          },
+          {
+            "uuid": "f8e35989-74b7-4a18-87ac-31e98b8d9004",
+            "display": "ONCOLOGYTRIAGE"
+          },
+          {
+            "uuid": "238625fc-8a25-44b2-aa5a-8bf48fa0e18d",
+            "display": "ONCOLOGYVIA"
+          }
+        ]
+      }
+
+    ]
+  },
+  "cad71628-692c-4d8f-8dac-b2e20bece27f": {
+    "name": "CERVICAL CANCER SCREENING PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+      {
+        "uuid": "8103a0f3-a3d3-4453-ac3e-aaecd542ccd1",
+        "name": "Cervical Cancer Screening ",
+        "encounterTypes": [
+          {
+            "uuid": "fc08ae1c-4588-443b-ae46-856bb20a5ee9",
+            "display": "OncologyDiagnosisChange"
+          },
+          {
+            "uuid": "9bc0fa73-474e-45ab-bdac-7282e95d856f",
+            "display": "ONCOLOGYDYSPLASIA"
+          },
+          {
+            "uuid": "d17b3adc-0837-4ac6-862b-0953fc664cb8",
+            "display": "OncologyInitial "
+          },
+          {
+            "uuid": "c7fd9ee7-c376-436d-a252-01e89cc51112",
+            "display": "OncologyLabandChemoTracking "
+          },
+          {
+            "uuid": "eeb9600c-314f-4071-9122-133ff3da37bb",
+            "display": "OncologyReturn"
+          },
+          {
+            "uuid": "49bd34db-39e8-4b70-bbba-676ccaf9fdd3",
+            "display": "OncologyReturnWithNewDiagnosticInfo"
+          },
+          {
+            "uuid": "f8e35989-74b7-4a18-87ac-31e98b8d9004",
+            "display": "ONCOLOGYTRIAGE"
+          },
+          {
+            "uuid": "238625fc-8a25-44b2-aa5a-8bf48fa0e18d",
+            "display": "ONCOLOGYVIA"
+          }
+        ]
+      }
+
+    ]
+  },
+  "43b42170-b3ce-4e03-9390-6bd78384ac06": {
+    "name": "CERVICAL CANCER TREATMENT PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+      {
+        "uuid": "b12cb85e-0c1e-4372-92ed-3bedcec1b105",
+        "name": "Cervical Cancer Treatment ",
+        "encounterTypes": [
+          {
+            "uuid": "5fa823ce-7592-482f-a0aa-361abf326ade",
+            "display": "HematOncologyTriage"
+          },
+          {
+            "uuid": "eeb9600c-314f-4071-9122-133ff3da37bb",
+            "display": "OncologyReturn"
+          },
+          {
+            "uuid": "d17b3adc-0837-4ac6-862b-0953fc664cb8",
+            "display": "OncologyInitial "
+          }
+        ]
+      }
+
+    ]
+  },
+  "88566621-828f-4569-9af5-c54f8237750a": {
+    "name": "BREAST CANCER TREATMENT PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+      {
+        "uuid": "e0d41d1c-47b5-4c97-b3c7-ba4e4268d9e6",
+        "name": "Breast Cancer Treatment ",
+        "encounterTypes": [
+          {
+            "uuid": "9ad5292c-14c3-489b-9c14-5f816e839691",
+            "display": "BreastCancerInitial"
+          },
+          {
+            "uuid": "e58469f1-f6be-4e53-a843-fb06f93c60ba",
+            "display": "BreastCancerReturn"
+          },
+          {
+            "uuid": "5fa823ce-7592-482f-a0aa-361abf326ade",
+            "display": "HematOncologyTriage"
+          }
+        ]
+      }
+
+    ]
+  },
+  "e48b266e-4d80-41f8-a56a-a8ce5449ebc6": {
+    "name": "SICKLE CELL PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+      {
+        "uuid": "ba3bd879-c66d-4288-80d4-8302d2b823a8",
+        "name": "Sickle cell ",
+        "encounterTypes": [
+          {
+            "uuid": "5fa823ce-7592-482f-a0aa-361abf326ade",
+            "display": "HematOncologyTriage"
+          },
+          {
+            "uuid": "ba5a15eb-576f-496b-a58d-e30b802a5da5",
+            "display": "SICKLECELLINITIAL"
+          },
+          {
+            "uuid": "3a0e7e4e-426e-4dc7-8f60-9114c43432eb",
+            "display": "SICKLECELLRETURN"
+          }
+        ]
+      }
+
+    ]
+  },
+  "698b7153-bff3-4931-9638-d279ca47b32e": {
+    "name": "MULTIPLE MYELOMA PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+      {
+        "uuid": "055436f7-cdc5-4e74-bef9-a8a06c746c3a",
+        "name": "Multiple Myeloma ",
+        "encounterTypes": [
+          {
+            "uuid": "5fa823ce-7592-482f-a0aa-361abf326ade",
+            "display": "HematOncologyTriage"
+          },
+          {
+            "uuid": "bf762b3e-b60a-436a-a40b-f874c59869ec",
+            "display": "MULTIPLEMYELOMAINITIAL"
+          },
+          {
+            "uuid": "50f307c4-b92e-4a41-bbbb-5cee1bd1c561",
+            "display": "MULTIPLEMYELOMARETURN"
+          }
+
+        ]
+      }
+
+    ]
+  },
+  "a3610ba4-9811-46b3-9628-83ec9310be13": {
+    "name": "HEMOPHILIA PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+      {
+        "uuid": "4c5cd268-0986-444e-8122-1160c4605884",
+        "name": "Hemophilia ",
+        "encounterTypes": [
+          {
+            "uuid": "5fa823ce-7592-482f-a0aa-361abf326ade",
+            "display": "HematOncologyTriage"
+          },
+          {
+            "uuid": "3945005a-c24f-478b-90ec-4af84ffcdf6b",
+            "display": "HEMOPHILIAINITIAL"
+          },
+          {
+            "uuid": "36927b3c-db32-4063-90df-e45640e9aabc",
+            "display": "HEMOPHILIARETURN"
+          }
+        ]
+      }
+
+    ]
+  },
+  "781d8880-1359-11df-a1f1-0026b9348838": {
+    "name": "EXPRESS CARE PROGRAM",
+    "dataDependencies": [
+      "patient",
+      "enrollment",
+      "hivLastTenClinicalEncounters"
+    ],
+    "visitTypes": [
+      {
+        "uuid": "e2c37c46-3ee9-4cff-9af6-aa5c41fb30da",
+        "name": "Express Care Visit ",
+        "encounterTypes": [
+          {
+            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
+            "display": "HIVTRIAGE"
+          },
+          {
+            "uuid": "cbe2d31d-2201-44ce-b52e-fbd5dc7cff33",
+            "display": "TRANSFERENCOUNTER"
+          },
+          {
+            "uuid": "df554398-1350-11df-a1f1-0026b9348838",
+            "display": "ECSTABLE"
+          }
+        ]
+      }
+
     ]
   }
 }

--- a/programs/resolve-to-encounterId.js
+++ b/programs/resolve-to-encounterId.js
@@ -1,0 +1,334 @@
+"use strict";
+
+/*
+
+This script resolves program, visitType and 
+encounterTypes to their respective encountertypes ids
+The ids resolved are used to filter data from
+tables such as hiv_flat_summary using the encounter_type
+field.
+By doing this we avoid using multiple joins i.e  to programs,
+visittypes and encountertype tables
+
+
+*/
+const _ = require('lodash');
+const dao = require('../etl-dao');
+const programsConfig = require('./program-visits-config');
+var encounterIds = [];
+
+var def = {
+     getProgramConf:  getProgramConf,
+     resolveToEncounterIds: resolveToEncounterIds,
+     resolveEncounterUuidToEncounterId : resolveEncounterUuidToEncounterId
+};
+/*
+var request = {
+    'programType': '781d85b0-1359-11df-a1f1-0026b9348838',
+    'visitType': '',
+    'encounterType':''
+}
+*/
+
+
+module.exports = def;
+
+function getProgramConf(){
+    return programsConfig;
+}
+
+function resolveToEncounterIds(request){
+
+      var totalAsyncRequests  = 0;
+
+    
+      if(request.programType){
+           var programTypeUuid = request.programType;
+      } else {
+           var programTypeUuid = '';
+      }
+       if(request.visitType){
+          var visitTypeUuid = request.visitType;
+      } else {
+          var visitTypeUuid = '';
+      }
+
+      if(request.encounterType){
+           var encounterTypeUuid = request.encounterType;
+       } else {
+           var encounterTypeUuid = '';
+       }
+
+
+      var encounterTypesList = [];
+      var resolvedEncounterUUids = [];
+
+     
+   
+
+      return new Promise((resolve, reject) => {
+
+          //consdition for resolving the promise
+
+           var checkAsyncState = function(){
+          if(totalAsyncRequests === 0){
+              resolve(resolvedEncounterUUids);
+            }
+           }
+
+         
+
+         
+        
+
+      // get the encounter types associated with a program
+
+      _.each(programsConfig,(program,index) => {
+
+            var progUuid = index;
+            var visitTypes = program.visitTypes;
+
+            var programLogic = getProgramsLogic(progUuid,programTypeUuid,visitTypeUuid,encounterTypeUuid);
+
+            if(programLogic === true){
+                 _.each(visitTypes,(visitType) => {
+                      var visitUuid = visitType.uuid;
+                      var encounterTypes = visitType.encounterTypes;
+                      var visitsLogic = getVisitsLogic(visitUuid,programTypeUuid,visitTypeUuid,encounterTypeUuid);
+
+                      if(visitsLogic === true){
+                        _.each(encounterTypes, (encounterType) => {
+                            var encounterUuid = encounterType.uuid;
+                            var encountersLogic = getEncountersLogic(encounterUuid,programTypeUuid,visitTypeUuid,encounterTypeUuid);
+
+                           if(encountersLogic === true){
+
+                                    var containsEncounterUuid = _.includes(encounterTypesList,encounterUuid);
+                                    // if(containsEncounterUuid === false){
+
+                                         encounterTypesList.push(encounterUuid);
+                                         totalAsyncRequests++;
+                                        resolveEncounterUuidToEncounterId(encounterUuid)
+                                                        .then(function (fulfilled) {                                                           
+                                                            let encounterId = parseInt(fulfilled);
+                                                            if(isNaN(encounterId) === false){
+                                                                 resolvedEncounterUUids.push(encounterId);
+                                                             }
+
+                                                            totalAsyncRequests--;
+                                                            checkAsyncState();
+
+                                                        })
+                                                        .catch(function (error) {
+                                                            console.log('Error Message',error);
+                                                        });
+                                       
+                                        
+
+                                    //}
+
+
+                            } else {
+                                //if encounters Logic fails
+                                 totalAsyncRequests++;
+                                resolveForFailedChecks()
+                                                .then(function (fulfilled) {
+                                                               var containsZeroid = _.includes(resolvedEncounterUUids,0);
+                                                                if(containsZeroid === false){
+                                                                    resolvedEncounterUUids.push(fulfilled);
+                                                                }
+
+                                                         totalAsyncRequests--;
+                                                         checkAsyncState();
+
+                                                    })
+                                                    .catch(function (error) {
+                                                        console.log('Error Message',error);
+                                                    });
+                            }
+                           
+                        });
+
+                      } else {
+                          // if visits logic fails
+                            //if the program check fails
+                                totalAsyncRequests++;
+                                resolveForFailedChecks()
+                                                .then(function (fulfilled) {
+                                                   
+
+                                                               var containsZeroid = _.includes(resolvedEncounterUUids,0);
+                                                                if(containsZeroid === false){
+                                                                    resolvedEncounterUUids.push(fulfilled);
+                                                                }
+
+                                                                 totalAsyncRequests--;
+                                                                 checkAsyncState();
+
+                                                    })
+                                                    .catch(function (error) {
+                                                        console.log('Error Message',error);
+                                                    });
+                                
+                         }
+
+               }); // end of visitType loop
+                 
+
+            } else {
+
+                //if the program check fails
+                 totalAsyncRequests++;
+                   resolveForFailedChecks()
+                                .then(function (fulfilled) {
+                                        var containsZeroid = _.includes(resolvedEncounterUUids,0);
+                                             if(containsZeroid === false){
+                                                resolvedEncounterUUids.push(fulfilled);
+                                             }
+                                             totalAsyncRequests--;
+                                             checkAsyncState();
+
+                                    })
+                                     .catch(function (error) {
+                                         console.log('Error Message',error.message);
+                                     });
+
+            }
+ 
+    
+      });
+
+        
+
+       
+
+
+      });
+
+
+}
+
+function resolveForFailedChecks(){
+    return new Promise((resolve, reject) => {
+      
+          resolve(0);
+
+
+    });
+}
+
+function getProgramsLogic(progUuid,programTypeUuid,visitTypeUuid,encounterTypeUuid){
+   
+
+     if(programTypeUuid!=''){
+           if(progUuid === programTypeUuid){
+                return true;
+           }else{
+               return false;
+           }
+     }else{
+
+           if (visitTypeUuid!='' || encounterTypeUuid!=''){
+                return true;
+           }else{
+               return false;
+           }
+
+     }
+    
+
+}
+
+function getVisitsLogic(visitUuid,programTypeUuid,visitTypeUuid,encounterTypeUuid){
+
+     if(visitTypeUuid !=''){
+         
+           if(visitTypeUuid === visitUuid){
+                return true;
+           } else {
+               return false;
+           }
+
+     } else {
+
+           if(programTypeUuid!='' || encounterTypeUuid!=''){
+                 return true;
+           }else {
+                 return false;
+           }
+     }
+
+}
+
+function getEncountersLogic(encounterUuid,programTypeUuid,visitTypeUuid,encounterTypeUuid){
+
+       if(encounterTypeUuid!=''){
+
+            if(encounterUuid === encounterTypeUuid){
+                 return true;
+            }
+            else{
+                return false;
+            }
+
+       } else {
+
+            if(programTypeUuid!='' || visitTypeUuid!=''){
+                 return true;
+             }else {
+                 return false;
+            }
+
+
+       }
+
+}
+
+
+function resolveEncounterUuidToEncounterId(encounterTypeUuid){
+
+    return new Promise((resolve, reject) => {
+      
+
+    var onResolvedPromise = function (promise) {
+
+        if(promise){
+            resolve(promise.results);
+        }else{
+            var reason = new Error('Error Getting UUid');
+            reject(reason);
+        }
+
+        
+    };
+
+
+     dao.getIdsByUuidAsyc('amrs.encounter_type', 'encounter_type_id', 'uuid', encounterTypeUuid , function(results){
+     }).onResolved = onResolvedPromise;
+
+        
+
+    });
+
+}
+
+
+
+// Test for Resolving Encounter IDS
+
+/*
+getProgramEncounterTypeUuids(request) 
+            .then(function (resolved) {
+                console.log('All Resolved',resolved);
+                return resolved;
+            })
+            .catch(function (error) {
+               return error;
+});
+
+*/
+
+
+
+
+

--- a/reports/daily-visits-appointment.report.json
+++ b/reports/daily-visits-appointment.report.json
@@ -315,6 +315,13 @@
         "alias": "t3",
         "joinExpression": "t1.person_id  = t3.person_id and (t3.voided is null || t3.voided = 0)"
       },
+       {
+        "joinType": "INNER JOIN",
+        "schema": "amrs",
+        "tableName": "encounter_type",
+        "alias": "t9",
+        "joinExpression": "t1.encounter_type  = t9.encounter_type_id"
+      },
       {
         "joinType": "INNER JOIN",
         "schema": "amrs",
@@ -363,6 +370,10 @@
         "defaultValue": []
       },
       {
+        "name": "encounterIds",
+        "defaultValue": []
+      },
+      {
         "name": "groupByPerson",
         "defaultValue": [
           {
@@ -390,6 +401,10 @@
       {
         "expression": "t1.location_id in (?)",
         "parameter": "locations"
+      },
+      {
+        "expression": "t1.encounter_type IN ?",
+        "parameter": "encounterIds"
       },
       {
         "expression": "coalesce(t1.death_date) is null",
@@ -425,6 +440,11 @@
         "sql": "t1.person_id"
       },
       {
+        "label": "name",
+        "type": "single",
+        "sql": "t9.name"
+      },
+      {
         "label": "uuid",
         "type": "single",
         "sql": "t1.uuid"
@@ -433,6 +453,16 @@
         "label": "encounter_id",
         "type": "single",
         "sql": "t1.encounter_id"
+      },
+      {
+        "label": "visit_id",
+        "type": "single",
+        "sql": "t1.visit_id"
+      },
+      {
+        "label": "encounter_type",
+        "type": "single",
+        "sql": "t1.encounter_type"
       },
       {
         "label": "given_name",


### PR DESCRIPTION
This script resolves program, visitType and encounterTypes to their respective encountertype ids
The ids resolved are used to filter data from tables such as hiv_flat_summary using the encounter_type
field.
By doing this we avoid using multiple joins i.e  to programs, visitTypes and encountertype tables
Paramenters for teching are named programType, visitType , encounterType