### PR TITLE
APTS-578: Arrange clinical visualization tabular report in ascendind …

### DIFF
--- a/reports/clinical-overview-visualization-report.json
+++ b/reports/clinical-overview-visualization-report.json
@@ -180,7 +180,7 @@
             {
                 "label": "reporting_month",
                 "type": "single",
-                "sql": "date_format(t2.endDate, '%m/%Y')"
+                "sql": "date_format(t2.endDate, '%Y/%m')"
             }
         ]
     },


### PR DESCRIPTION
This ticket fixed the bug in clinical visualization tabular report.As it is the reporting month is using the format
m/y which causes an error in sorting.Changing to y/m fixes the sorting issue