### PR TITLE
POCAMRS-269: Add Validation to PrEP visit

### DIFF
--- a/programs/patient-data-resolver.service.js
+++ b/programs/patient-data-resolver.service.js
@@ -1,130 +1,147 @@
-var Promise = require('bluebird');
-var _ = require('underscore');
+const Promise = require('bluebird');
 
-var patientService = require('../service/openmrs-rest/patient.service.js');
-var programService = require('../service/openmrs-rest/program.service');
-var etlHivSummary = require('../dao/patient/etl-patient-hiv-summary-dao');
+const patientService = require('../service/openmrs-rest/patient.service.js');
+const programService = require('../service/openmrs-rest/program.service');
+const etlHivSummary = require('../dao/patient/etl-patient-hiv-summary-dao');
+const encounterService = require('../service/openmrs-rest/encounter');
 
-var availableKeys = {
-    'patient': getPatient,
-    'dummyPatient': getPatient,
-    'enrollment': getProgramEnrollment,
-    'hivLastTenClinicalEncounters': gethivLastTenClinicalEncounters,
-    'hivLastEncounter': getPatientLastEncounter,
-    'patientEnrollment': getPatientEnrollement
+const availableKeys = {
+  'patient': getPatient,
+  'dummyPatient': getPatient,
+  'enrollment': getProgramEnrollment,
+  'hivLastTenClinicalEncounters': gethivLastTenClinicalEncounters,
+  'hivLastEncounter': getPatientLastEncounter,
+  'patientEnrollment': getPatientEnrollement,
+  'patientEncounters': getPatientEncounters
 };
 
-var def = {
-    getPatient: getPatient,
-    getProgramEnrollment: getProgramEnrollment,
-    gethivLastTenClinicalEncounters: gethivLastTenClinicalEncounters,
-    getAllDataDependencies: getAllDataDependencies,
-    availableKeys: availableKeys,
-    getPatientLastEncounter: getPatientLastEncounter
+const def = {
+  getPatient: getPatient,
+  getProgramEnrollment: getProgramEnrollment,
+  gethivLastTenClinicalEncounters: gethivLastTenClinicalEncounters,
+  getAllDataDependencies: getAllDataDependencies,
+  availableKeys: availableKeys,
+  getPatientLastEncounter: getPatientLastEncounter,
+  getPatientEncounters: getPatientEncounters
 };
 
 module.exports = def;
 
 function getAllDataDependencies(dataDependenciesKeys,
-    patientUuid, params) {
-    return new Promise(function (success, error) {
-        var dataObject = {};
-        Promise.reduce(dataDependenciesKeys,
-            function (previous, key) {
-
-                return availableKeys[key](patientUuid, params)
-                    .then(function (data) {
-                        dataObject[key] = data;
-                    })
-                    .catch(function (err) {
-                        dataObject[key] =
-                            {
-                                error: 'An error occured',
-                                detail: err
-                            };
-                    });
-
-            }, 0)
-            .then(function (data) {
-                success(dataObject);
-            })
-            .catch(function (err) {
-                error(err);
-            });
-    });
+  patientUuid, params) {
+  return new Promise(((success, error) => {
+    const dataObject = {};
+    Promise.reduce(dataDependenciesKeys,
+      function (previous, key) {
+        return availableKeys[key](patientUuid, params)
+          .then(function (data) {
+            dataObject[key] = data;
+          })
+          .catch(function (err) {
+            dataObject[key] = {
+              error: 'An error occured',
+              detail: err
+            };
+          });
+      }, 0)
+        .then(function (data) {
+          success(dataObject);
+        })
+        .catch(function (err) {
+          error(err);
+        });
+  }));
 }
 
 function getPatient(patientUuid, params) {
-    return new Promise(
-        function (resolve, reject) {
-            patientService.getPatientByUuid(patientUuid, { rep: 'full' })
-                .then(function (patient) {
-                    resolve(patient);
-                })
-                .catch(function (error) {
-                    reject(error);
-                });
-        }
-    );
+  return new Promise(
+    ((resolve, reject) => {
+      patientService.getPatientByUuid(patientUuid, { rep: 'full' })
+        .then((patient) => {
+          resolve(patient);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    }),
+  );
 }
 
 function getProgramEnrollment(patientUuid, params) {
+  return new Promise(
+    ((resolve, reject) => {
+      programService.getProgramEnrollmentByUuid(params.programEnrollmentUuid,
+        {
+          rep: 'custom:(uuid,display,voided,dateEnrolled,dateCompleted,location,'
+            + 'program:(uuid),states:(uuid,startDate,endDate,state:(uuid,initial,terminal,'
+            + 'concept:(uuid,display))))',
+        })
+        .then((enrollment) => {
+          resolve(enrollment);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    }),
+  );
+}
 
-    return new Promise(
-        function (resolve, reject) {
-            programService.getProgramEnrollmentByUuid(params.programEnrollmentUuid,
-                { rep: 'custom:(uuid,display,voided,dateEnrolled,dateCompleted,location,' +
-                'program:(uuid),states:(uuid,startDate,endDate,state:(uuid,initial,terminal,' +
-                'concept:(uuid,display))))' })
-                .then(function (enrollment) {
-                    resolve(enrollment);
-                })
-                .catch(function (error) {
-                    reject(error);
-                });
-        }
-    );
+function getPatientEncounters(patientUuid) {
+  const patientEncounters = encounterService.getPatientEncounters({
+    patientUuid,
+    v: 'custom:(encounterType:(uuid,display))',
+  });
 
+  return new Promise(((resolve, reject) => {
+    patientEncounters
+      .then((encounters) => {
+        resolve(encounters);
+      })
+      .catch((e) => {
+        console.error('An error occurred fetching encounters: ', e);
+        reject(e);
+      });
+  }));
 }
 
 function gethivLastTenClinicalEncounters(patientUuid, params) {
-    return new Promise(
-        function (resolve, reject) {
-            etlHivSummary.getPatientHivSummary(patientUuid, true, {}, 0, 10)
-                .then(function (response) {
-                    resolve(response.result);
-                })
-                .catch(function (error) {
-                    reject(error);
-                });
-        }
-    );
+  return new Promise(
+    ((resolve, reject) => {
+      etlHivSummary.getPatientHivSummary(patientUuid, true, {}, 0, 10)
+        .then((response) => {
+          resolve(response.result);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    }),
+  );
 }
 
 function getPatientLastEncounter(patientUuid) {
-    return new Promise(
-        function (resolve, reject) {
-            etlHivSummary.getPatientLastEncounter(patientUuid)
-                .then(function (response) {
-                    resolve(response.result[0]);
-                })
-                .catch(function (error) {
-                    reject(error);
-                });
-        }
-    );
+  return new Promise(
+    ((resolve, reject) => {
+      etlHivSummary.getPatientLastEncounter(patientUuid)
+        .then((response) => {
+          resolve(response.result[0]);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    }),
+  );
 }
 
 function getPatientEnrollement(patientUuid, params) {
-    return new Promise(
-        function (resolve, reject) {
-            programService.getProgramEnrollmentByPatientUuid(patientUuid, params)
-                .then(function (response) {
-                    resolve(response.results);
-                })
-                .catch(function (error) {
-                    reject(error);
-                });
-        }
-    );
+  return new Promise(
+    ((resolve, reject) => {
+      programService.getProgramEnrollmentByPatientUuid(patientUuid, params)
+        .then((response) => {
+          resolve(response.results);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    }),
+  );
 }

--- a/programs/patient-program-config.json
+++ b/programs/patient-program-config.json
@@ -1290,7 +1290,8 @@
     "dataDependencies": [
       "patient",
       "enrollment",
-      "hivLastTenClinicalEncounters"
+      "hivLastTenClinicalEncounters",
+      "patientEncounters"
     ],
     "enrollmentOptions": {
       "requiredProgramQuestions": [{
@@ -1341,9 +1342,12 @@
       "0904172d-0b6a-40df-b8a2-b3653d16dc45",
       "a8e7c30d-6d2f-401c-bb52-d4433689a36b"
     ],
-    "visitTypes": [{
-        "uuid": "330d9739-833d-48a8-8986-f1069c320194",
-        "name": "PrEP Visit ",
+    "visitTypes": [
+      {
+        "uuid": "a0ee8015-3558-4ac8-9886-285f9b687c2f",
+        "name": "PrEP Initial Visit",
+        "allowedIf": "isFirstPrEPVisit",
+        "message": "Patient must not have a prior clinical encounter.",
         "encounterTypes": [{
             "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
             "display": "HIVTRIAGE"
@@ -1351,6 +1355,33 @@
           {
             "uuid": "00ee2fd6-9c95-4ffc-ab31-6b1ce2dede4d",
             "display": "PREPINITIAL"
+          },
+          {
+            "uuid": "df55584c-1350-11df-a1f1-0026b9348838",
+            "display": "DEATHREPORT"
+          },
+          {
+            "uuid": "1469e5fe-ad76-4041-9aa7-650e6afbe3a1",
+            "display": "DERMATOLOGYREFERRAL"
+          },
+          {
+            "uuid": "ae35ed69-e07c-4209-93ce-f23733aa816b",
+            "display": "FAMILYSTATUS"
+          },
+          {
+            "uuid": "df5547bc-1350-11df-a1f1-0026b9348838",
+            "display": "OUTREACHFIELDFU"
+          }
+        ]
+      },
+      {
+        "uuid": "a3ecf6ef-05ec-4742-a4c1-8db750e18364",
+        "name": "PrEP Return Visit",
+        "allowedIf": "!isFirstPrEPVisit",
+        "message": "Patient must have a prior clinical encounter.",
+        "encounterTypes": [{
+            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
+            "display": "HIVTRIAGE"
           },
           {
             "uuid": "ddd96f1c-524f-4caa-81a6-1a6f9789a4bc",

--- a/programs/scope-builder.service.js
+++ b/programs/scope-builder.service.js
@@ -1,76 +1,82 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-var def = {
-    buildScope: buildScope
+const def = {
+  buildScope: buildScope
 };
 
 module.exports = def;
 
 function buildScope(dataDictionary) {
+  const scope = {
+    hasPreviousInitialVisit: false
+  };
+  
+  if (dataDictionary.patient) {
+    buildPatientScopeMembers(scope, dataDictionary.patient);
+  }
 
-    var scope = {
-        hasPreviousInitialVisit: false
-    };
-    if (dataDictionary.patient) {
-        buildPatientScopeMembers(scope, dataDictionary.patient);
-    }
+  if (dataDictionary.enrollment) {
+    buildProgramScopeMembers(scope, dataDictionary.enrollment);
+  }
 
-    if (dataDictionary.enrollment) {
-        buildProgramScopeMembers(scope, dataDictionary.enrollment);
-    }
-
-    if (dataDictionary.patientEnrollment) {
-
-      var activeEnrollments = _.filter(dataDictionary.patientEnrollment, { dateCompleted: null});
-      var isEnrolledInPMTCT = false;
-      var isEnrolledInViremia = false;
-      activeEnrollments.forEach(function(item) {
-        if (item.program.uuid === 'c4246ff0-b081-460c-bcc5-b0678012659e') {
-          isEnrolledInViremia = true;
-        }
-        if (item.program.uuid === '781d897a-1359-11df-a1f1-0026b9348838') {
-          isEnrolledInPMTCT = true;
-        }
-      });
-
-      if (isEnrolledInPMTCT && isEnrolledInViremia) {
-        scope.isEnrolledInViremiaPMTCT = true;
-      } else {
-        scope.isEnrolledInViremiaPMTCT = false;
+  if (dataDictionary.patientEnrollment) {
+    const activeEnrollments = _.filter(dataDictionary.patientEnrollment, { dateCompleted: null});
+    let isEnrolledInPMTCT = false;
+    let isEnrolledInViremia = false;
+    
+    activeEnrollments.forEach((item) => {
+      if (item.program.uuid === 'c4246ff0-b081-460c-bcc5-b0678012659e') {
+        isEnrolledInViremia = true;
       }
+      
+      if (item.program.uuid === '781d897a-1359-11df-a1f1-0026b9348838') {
+        isEnrolledInPMTCT = true;
+      }
+    });
 
+    if (isEnrolledInPMTCT && isEnrolledInViremia) {
+      scope.isEnrolledInViremiaPMTCT = true;
+    } else {
+      scope.isEnrolledInViremiaPMTCT = false;
     }
+  }
 
-    if (dataDictionary.hivLastTenClinicalEncounters) {
-        buildHivScopeMembers(scope, dataDictionary.hivLastTenClinicalEncounters,
-          dataDictionary.intendedVisitLocationUuid);
-    }
+  if (dataDictionary.hivLastTenClinicalEncounters) {
+    buildHivScopeMembers(scope, dataDictionary.hivLastTenClinicalEncounters,
+    dataDictionary.intendedVisitLocationUuid);
+  }
 
-    if (dataDictionary.hivLastEncounter) {
-        if (dataDictionary.hivLastEncounter.months_from_last_visit >= 5) {
-            scope.qualifiesForStandardVisit = true;
-        } else {
-            scope.qualifiesForStandardVisit = false;
-        }
+  if (dataDictionary.hivLastEncounter) {
+    if (dataDictionary.hivLastEncounter.months_from_last_visit >= 5) {
+      scope.qualifiesForStandardVisit = true;
+    } else {
+      scope.qualifiesForStandardVisit = false;
     }
+  }
 
-    if (dataDictionary.intendedVisitLocationUuid) {
-        scope.intendedVisitLocationUuid = dataDictionary.intendedVisitLocationUuid;
-    }
-    if (dataDictionary.hasPreviousInitialVisit) {
-        scope.hasPreviousInitialVisit = dataDictionary.hasPreviousInitialVisit;
-    }
-    // console.log('buildScope scope', scope);
-    // add other methods to build the scope objects
-    return scope;
+  if (dataDictionary.intendedVisitLocationUuid) {
+    scope.intendedVisitLocationUuid = dataDictionary.intendedVisitLocationUuid;
+  }
+
+  if (dataDictionary.hasPreviousInitialVisit) {
+    scope.hasPreviousInitialVisit = dataDictionary.hasPreviousInitialVisit;
+  }
+ 
+  if (dataDictionary.patientEncounters) {
+    scope.patientEncounters = dataDictionary.patientEncounters;
+    buildHivScopeMembers(scope, dataDictionary.patientEncounters);
+  }
+
+  // add other methods to build the scope objects
+  return scope;
 }
 
 function buildPatientScopeMembers(scope, patient) {
-    scope.age = patient.person.age;
-    scope.gender = patient.person.gender;
+  scope.age = patient.person.age;
+  scope.gender = patient.person.gender;
 }
 
-function isIntraTransfer (lastTenHivSummary, intendedVisitLocationUuid) {
+function isIntraTransfer(lastTenHivSummary, intendedVisitLocationUuid) {
   if (intendedVisitLocationUuid && Array.isArray(lastTenHivSummary) && lastTenHivSummary.length > 0) {
     return intendedVisitLocationUuid !== lastTenHivSummary[0].location_uuid;
   } else {
@@ -78,31 +84,43 @@ function isIntraTransfer (lastTenHivSummary, intendedVisitLocationUuid) {
   }
 }
 
+function isInitialPrepVisit(patientEncounters) {
+  const initialPrEPEncounterUuid = '00ee2fd6-9c95-4ffc-ab31-6b1ce2dede4d';
+  let previousPrEPEncounters = [];
+
+  previousPrEPEncounters = _.filter(patientEncounters, (encounter) => {
+    return encounter.encounterType.uuid === initialPrEPEncounterUuid;
+  });
+
+  return previousPrEPEncounters.length === 0;
+}
+
 function buildProgramScopeMembers(scope, programEnrollment) {
-    if (programEnrollment && programEnrollment.location &&
-        programEnrollment.location.uuid) {
-        scope.programLocation = programEnrollment.location.uuid;
-    }
+  if (programEnrollment && programEnrollment.location &&
+    programEnrollment.location.uuid) {
+    scope.programLocation = programEnrollment.location.uuid;
+  }
+  
+  if (programEnrollment && programEnrollment.states) {
+    const states = programEnrollment.states;
+    const currentState = states.filter(state => state.endDate === null);
     
-    if(programEnrollment && programEnrollment.states) {
-      var states = programEnrollment.states;
-      var currentState = states.filter(function(state){
-        return state.endDate === null;
-      });
-      if(currentState.length > 0) {
-        var state = currentState[0].state;
-        scope.inCareUuid = state.concept.uuid;
-      }
+    if (currentState.length > 0) {
+      const state = currentState[0].state;
+      scope.inCareUuid = state.concept.uuid;
     }
+  }
 }
 
 function buildHivScopeMembers(scope, lastTenHivSummary, intendedVisitLocationUuid) {
-    if (Array.isArray(lastTenHivSummary) && lastTenHivSummary.length > 0) {
-        scope.isFirstAMPATHHIVVisit = false;
-        scope.previousHIVClinicallocation = lastTenHivSummary[0].location_uuid;
-    } else {
-      // its first AMPATH visit if its not an intra transfer
-        scope.isFirstAMPATHHIVVisit = !isIntraTransfer(lastTenHivSummary, intendedVisitLocationUuid);
-        scope.previousHIVClinicallocation = null;
-    }
+  if (Array.isArray(lastTenHivSummary) && lastTenHivSummary.length > 0) {
+    scope.isFirstAMPATHHIVVisit = false;
+    scope.previousHIVClinicallocation = lastTenHivSummary[0].location_uuid;
+  } else {
+    // its first AMPATH visit if its not an intra transfer
+    scope.isFirstAMPATHHIVVisit = !isIntraTransfer(lastTenHivSummary, intendedVisitLocationUuid);
+    scope.previousHIVClinicallocation = null;
+  }
+  // It's a first PrEP visit if the patient has no previous PrEP encounters
+  scope.isFirstPrEPVisit = isInitialPrepVisit(scope.patientEncounters);
 }


### PR DESCRIPTION
This ticket adds two new visit types as well as visit-level validation to the Pre-Exposure Prophylaxis (PrEP) program. 

Previously, upon starting a PrEP visit, the system would display both Initial and Return encounter forms for clients enrolled in the PrEP program regardless of whether they had previous PrEP encounters or not. 

This ticket fixes this problem by replacing the original PrEP visit with two new visit types: PrEP Initial visit and PrEP Return visit. It also validates the new visits so that:

- If a patient had a PrEP encounter, the Return visit is displayed while the Initial visit is hidden.
- Otherwise, if a patient did not have a PrEP encounter, the Initial visit is displayed while the Return visit is hidden.