### PR TITLE
POCAMRS-273: Add validation to PEP visit

### DIFF
--- a/programs/patient-program-config.json
+++ b/programs/patient-program-config.json
@@ -1262,7 +1262,8 @@
     "dataDependencies": [
       "patient",
       "enrollment",
-      "hivLastTenClinicalEncounters"
+      "hivLastTenClinicalEncounters",
+      "patientEncounters"
     ],
     "enrollmentOptions": {
       "requiredProgramQuestions": [{
@@ -1308,20 +1309,48 @@
       "0904172d-0b6a-40df-b8a2-b3653d16dc45",
       "a8e7c30d-6d2f-401c-bb52-d4433689a36b"
     ],
-    "visitTypes": [{
-        "uuid": "58f20c53-aac7-4e73-bd7a-97986435e570",
-        "name": "PEP Visit ",
-        "encounterTypes": [{
-            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
-            "display": "HIVTRIAGE"
-          },
+    "visitTypes": [
+      {
+        "uuid": "61207315-1e69-4453-9d32-8eb0027cf2f5",
+        "name": "PEP Initial Visit",
+        "allowedIf": "isFirstPEPVisit",
+        "message": "Patient must not have a prior clinical encounter.",
+        "encounterTypes": [
           {
             "uuid": "c3a78744-f94a-4a25-ac9d-1c48df887895",
             "display": "PEPINITIAL"
           },
           {
+            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
+            "display": "HIVTRIAGE"
+          },
+          {
+            "uuid": "df55584c-1350-11df-a1f1-0026b9348838",
+            "display": "DEATHREPORT"
+          },
+          {
+            "uuid": "1469e5fe-ad76-4041-9aa7-650e6afbe3a1",
+            "display": "DERMATOLOGYREFERRAL"
+          },
+          {
+            "uuid": "ae35ed69-e07c-4209-93ce-f23733aa816b",
+            "display": "FAMILYSTATUS"
+          }
+        ]
+      },
+      {
+        "uuid": "234e7374-2c3f-4cf3-a6b8-655cafb45cd4",
+        "name": "PEP Return Visit",
+        "allowedIf": "!isFirstPEPVisit",
+        "message": "Patient must have a prior clinical encounter.",
+        "encounterTypes": [
+          {
             "uuid": "f091b833-9e1a-4eef-8364-fc289095a832",
             "display": "PEPRETURN"
+          },
+          {
+            "uuid": "a44ad5e2-b3ec-42e7-8cfa-8ba3dbcf5ed7",
+            "display": "HIVTRIAGE"
           },
           {
             "uuid": "df55584c-1350-11df-a1f1-0026b9348838",

--- a/programs/scope-builder.service.js
+++ b/programs/scope-builder.service.js
@@ -97,6 +97,17 @@ function isInitialPrepVisit(patientEncounters) {
   return initialPrEPEncounters.length === 0;
 }
 
+function isInitialPepVisit(patientEncounters) {
+  const initialPEPEncounterUuid = 'c3a78744-f94a-4a25-ac9d-1c48df887895';
+  let initialPEPEncounters = [];
+
+  initialPEPEncounters = _.filter(patientEncounters, (encounter) => {
+    return encounter.encounterType.uuid === initialPEPEncounterUuid;
+  });
+
+  return initialPEPEncounters.length === 0;
+}
+
 function isInitialOncologyVisit(encounters, programUuid) {
   const oncologyProgramEncounterTypeMap = [
     {
@@ -128,15 +139,16 @@ function isInitialOncologyVisit(encounters, programUuid) {
       initialEncounterUuid: '4a7450b1-f720-4a0c-b13b-d8a6a83348ee' // Anticoagulation Initial
     }
   ];
+
   let initialOncologyEncounters = [];
   let initialEncounterType = oncologyProgramEncounterTypeMap.find(e => e.programUuid === programUuid);
+  
   if (initialEncounterType) {
     initialOncologyEncounters = _.filter(encounters, encounter => {
       return initialEncounterType.initialEncounterUuid === encounter.encounterType.uuid
     });
   }
   return initialOncologyEncounters.length === 0;
-  
 }
 
 function buildProgramScopeMembers(scope, programEnrollment) {
@@ -165,8 +177,9 @@ function buildHivScopeMembers(scope, lastTenHivSummary, intendedVisitLocationUui
     scope.isFirstAMPATHHIVVisit = !isIntraTransfer(lastTenHivSummary, intendedVisitLocationUuid);
     scope.previousHIVClinicallocation = null;
   }
-  // It's a first PrEP visit if the patient has no previous PrEP encounters
+  
   scope.isFirstPrEPVisit = isInitialPrepVisit(scope.patientEncounters);
+  scope.isFirstPEPVisit = isInitialPepVisit(scope.patientEncounters);
 }
 
 function buildOncologyScopeMembers(scope, patientEncounters, programUuid) {


### PR DESCRIPTION
Previously, upon starting a PEP visit, the system would display both Initial and Return encounter forms for clients enrolled in the PEP program regardless of whether they had previous PEP encounters or not.

This ticket replaces the PEP visit with two new visit types: PEP Initial and PEP Return. It also adds validation to the new visit types so that:

- If a patient did not have a PEP encounter, the Initial visit is displayed while the Return visit is hidden.
- Otherwise, If a patient had a PEP encounter, the Return visit is displayed while the Initial visit is hidden.