### PR TITLE
HIV-427: Add Youth Return encounter type to Standard HIV Visit in the DC Program

### DIFF
--- a/programs/patient-program-config.json
+++ b/programs/patient-program-config.json
@@ -1820,6 +1820,10 @@
           {
             "uuid": "df55584c-1350-11df-a1f1-0026b9348838",
             "display": "DEATHREPORT"
+          },
+          {
+            "uuid": "4e7553b4-373d-452f-bc89-3f4ad9a01ce7",
+            "display": "YOUTHRETURN"
           }
           
           


### PR DESCRIPTION
Adds Youth Return Form to the Standard HIV Visit for Differentiated Care in the Differentiated Care Program.