### PR TITLE
EID-FIX: Fix incorrect mflCode for Moi University Main Campus clinic

### DIFF
--- a/service/eid/eid-facility-mappings.json
+++ b/service/eid/eid-facility-mappings.json
@@ -635,7 +635,7 @@
         "cityVillage": "Kesses",
         "county": "",
         "description": "Moi University  Main Campus clinic",
-        "mflCode": "14841",
+        "mflCode": "15205",
         "eidDisplay": ""
     },
     "0900acea-1352-11df-a1f1-0026b9348838": {


### PR DESCRIPTION
The master facility list (MFL) code we have on record for the Moi University clinic is not the same as what appears on the Kenya Master Health Facility List website http://kmhfl.health.go.ke/#/home and the EID lab system. This commit changes the MFL code for that facility to the correct one.