### PR TITLE
POCONC-160: Fix medication history date on oncology diagnosis summary

### DIFF
--- a/app/routes/patient-medication-history.route.js
+++ b/app/routes/patient-medication-history.route.js
@@ -35,7 +35,7 @@ const routes = [{
                                         oncMed.cur_onc_meds_route = helpers.getConceptName(a.value_coded);
                                     }
                                     if (planAndDate.length > 0) {
-                                        oncMed.meds_start_date = planAndDate[0].obs_datetime;
+                                        oncMed.meds_start_date = helpers.filterDate(planAndDate[0].obs_datetime);
                                         oncMed.chemotherapy_plan = helpers.getConceptName(planAndDate[0].value_coded);
                                     }
                                 });


### PR DESCRIPTION
Presently, the date being displayed on the medication history summary in the oncology screening and diagnosis program summary is in ISO 8601 format e.g. 2019-01-23T10:20:06.000Z. The fix introduced changes it to the more readable YYYY-MM-DD format e.g 2019-01-23.