### PR TITLE
POCONC-170: Wrong numbers in combined cervical cancer screening report

### DIFF
--- a/app/reporting-framework/json-reports/combined-breast-cervical-cancer-daily-screening-summary-base.json
+++ b/app/reporting-framework/json-reports/combined-breast-cervical-cancer-daily-screening-summary-base.json
@@ -206,7 +206,7 @@
             },
             {
                 "filterType": "tableColumns",
-                "conditionExpression": "pp.program_id in (12, 13)"
+                "conditionExpression": "pp.program_id in (12, 13, 40)"
             }
         ]
     },

--- a/app/reporting-framework/json-reports/combined-breast-cervical-cancer-monthly-screening-summary-base.json
+++ b/app/reporting-framework/json-reports/combined-breast-cervical-cancer-monthly-screening-summary-base.json
@@ -206,7 +206,7 @@
             },
             {
                 "filterType": "tableColumns",
-                "conditionExpression": "pp.program_id  in (12, 13)"
+                "conditionExpression": "pp.program_id  in (12, 13, 40)"
             }
         ]
     },


### PR DESCRIPTION
Presently, the figures being displayed in the amalgamated screening report for breast and cervical cancer screening are erroneous. This is a consequence of unifying the breast and cervical cancer screening programs into the oncology and diagnosis screening program (#787). This PR adds the program_id for this new program to the program_id condition in the WHERE clause of the SQL query used to generate the report.