### PR TITLE
POCONC-172: Add columns to breast & cervical patient lists for abnormal findings

### DIFF
--- a/app/reporting-framework/json-reports/breast-cancer-daily-screening-summary-aggregate.json
+++ b/app/reporting-framework/json-reports/breast-cancer-daily-screening-summary-aggregate.json
@@ -44,18 +44,18 @@
     },
     {
       "type": "derived_column",
-      "alias": "normal_breast_screening_findings",
+      "alias": "normal_findings",
       "expressionType": "simple_expression",
       "expressionOptions": {
-        "expression": "count(normal_breast_screening_findings)"
+        "expression": "count(normal_findings)"
       }
     },
     {
       "type": "derived_column",
-      "alias": "abnormal_breast_screening_findings",
+      "alias": "abnormal_findings",
       "expressionType": "simple_expression",
       "expressionOptions": {
-        "expression": "count(abnormal_breast_screening_findings)"
+        "expression": "count(abnormal_findings)"
       }
     },
     {
@@ -63,7 +63,135 @@
       "alias": "normal_breast_call_rate%",
       "expressionType": "simple_expression",
       "expressionOptions": {
-        "expression": " ROUND(count(normal_breast_screening_findings)/count(person_id)*100,2)"
+        "expression": " ROUND(count(normal_findings)/count(person_id)*100,2)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_breast_call_rate%",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "ROUND(count(abnormal_findings)/count(person_id)*100,2)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "male_patients",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(male_patients)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "female_patients",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(female_patients)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status_unknown",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_status_unknown)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_below_30yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_below_30yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_30_to_40yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_30_to_40yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_41_to_50yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_41_to_50yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_51_to_69yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_51_to_69yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_above_70yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_above_70yrs)"
       }
     }
   ],

--- a/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-aggregate.json
+++ b/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-aggregate.json
@@ -1,181 +1,220 @@
 {
-    "name": "breastCancerMonthlySummaryAggregate",
-    "version": "1.0",
-    "tag": "breast_cancer_summary_aggregate",
-    "uses": [
-        {
-            "name": "breastCancerMonthlySummaryBase",
-            "version": "1.0",
-            "type": "dataset_def"
-        }
-    ],
-    "sources": [
-        {
-            "dataSet": "breastCancerMonthlySummaryBase",
-            "alias": "bcsd"
-        }
-    ],
-    "columns": [
-        {
-            "type": "simple_column",
-            "alias": "location_name",
-            "column": "location_name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_uuid",
-            "column": "location_uuid"
-        },
-        {
-            "type": "derived_column",
-            "alias": "encounter_datetime",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "date_format(bcsd.encounter_datetime, '%m-%Y')"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "total_breast_screened",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(person_id)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_call_rate%",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": " ROUND(count(normal_breast_screening_findings)/count(person_id)*100,2)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_call_rate%",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "ROUND(count(abnormal_breast_screening_findings)/count(person_id)*100,2)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_breast_screening_findings)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_below_30yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_breast_screening_findings_below_30yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_30_to_40yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_breast_screening_findings_30_to_40yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_41_to_50yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_breast_screening_findings_41_to_50yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_51_to_69yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_breast_screening_findings_51_to_69yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_above_70yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_breast_screening_findings_above_70yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_breast_screening_findings)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_below_30yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_breast_screening_findings_below_30yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_30_to_40yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_breast_screening_findings_30_to_40yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_41_to_50yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_breast_screening_findings_41_to_50yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_51_to_69yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_breast_screening_findings_51_to_69yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_above_70yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_breast_screening_findings_above_70yrs)"
-            }
-        }
-    ],
-    "groupBy": {
-        "groupParam": "groupByParam",
-        "columns": [
-            "location_id",
-            "year(bcsd.encounter_datetime)",
-            "month(bcsd.encounter_datetime)"
-        ],
-        "excludeParam": "excludeParam"
-    },
-    "dynamicJsonQueryGenerationDirectives": {
-        "patientListGenerator": {
-            "useTemplate": "breast_cancer_patient_list_template",
-            "useTemplateVersion": "1.0",
-            "generatingDirectives": {
-                "joinDirectives": {
-                    "joinType": "INNER",
-                    "joinCondition": "<<base_column>> = <<template_column>>",
-                    "baseColumn": "person_id",
-                    "templateColumn": "person_id"
-                }
-            }
-        }
+  "name": "breastCancerMonthlySummaryAggregate",
+  "version": "1.0",
+  "tag": "breast_cancer_summary_aggregate",
+  "uses": [
+      {
+          "name": "breastCancerMonthlySummaryBase",
+          "version": "1.0",
+          "type": "dataset_def"
+      }
+  ],
+  "sources": [
+      {
+          "dataSet": "breastCancerMonthlySummaryBase",
+          "alias": "bcsd"
+      }
+  ],
+  "columns": [{
+    "type": "simple_column",
+    "alias": "location_name",
+    "column": "location_name"
+  },
+  {
+    "type": "simple_column",
+    "alias": "location_uuid",
+    "column": "location_uuid"
+  },
+  {
+    "type": "derived_column",
+    "alias": "encounter_datetime",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "date_format(bcsd.encounter_datetime, '%m-%Y')"
     }
+  },
+  {
+    "type": "derived_column",
+    "alias": "total_breast_screened",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(person_id)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "normal_findings",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(normal_findings)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "abnormal_findings",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(abnormal_findings)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "normal_breast_call_rate%",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": " ROUND(count(normal_findings)/count(person_id)*100,2)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "abnormal_breast_call_rate%",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "ROUND(count(abnormal_findings)/count(person_id)*100,2)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "male_patients",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(male_patients)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "female_patients",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(female_patients)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "hiv_negative",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(hiv_negative)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "hiv_status_unknown",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(hiv_status_unknown)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "hiv_positive",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(hiv_positive)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "normal_below_30yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(normal_below_30yrs)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "abnormal_below_30yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(abnormal_below_30yrs)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "normal_30_to_40yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(normal_30_to_40yrs)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "abnormal_30_to_40yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(abnormal_30_to_40yrs)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "normal_41_to_50yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(normal_41_to_50yrs)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "abnormal_41_to_50yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(abnormal_41_to_50yrs)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "normal_51_to_69yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(normal_51_to_69yrs)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "abnormal_51_to_69yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(abnormal_51_to_69yrs)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "normal_above_70yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(normal_above_70yrs)"
+    }
+  },
+  {
+    "type": "derived_column",
+    "alias": "abnormal_above_70yrs",
+    "expressionType": "simple_expression",
+    "expressionOptions": {
+      "expression": "count(abnormal_above_70yrs)"
+    }
+  }
+],
+  "groupBy": {
+      "groupParam": "groupByParam",
+      "columns": [
+          "location_id",
+          "year(bcsd.encounter_datetime)",
+          "month(bcsd.encounter_datetime)"
+      ],
+      "excludeParam": "excludeParam"
+  },
+  "dynamicJsonQueryGenerationDirectives": {
+      "patientListGenerator": {
+          "useTemplate": "breast_cancer_patient_list_template",
+          "useTemplateVersion": "1.0",
+          "generatingDirectives": {
+              "joinDirectives": {
+                  "joinType": "INNER",
+                  "joinCondition": "<<base_column>> = <<template_column>>",
+                  "baseColumn": "person_id",
+                  "templateColumn": "person_id"
+              }
+          }
+      }
+  }
 }

--- a/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-base.json
+++ b/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-base.json
@@ -1,389 +1,841 @@
 {
-    "name": "breastCancerMonthlySummaryBase",
-    "version": "1.0",
-    "tag": "breast_cancer_monthly_summary_base",
-    "uses": [],
-    "sources": [
-        {
-            "table": "etl.flat_breast_cancer_screening",
-            "alias": "fbcs"
-        },
-        {
-            "table": "amrs.person_name",
-            "alias": "patient_name",
-            "join": {
-                "type": "inner",
-                "joinCondition": "fbcs.person_id = patient_name.person_id and (patient_name.voided is null || patient_name.voided = 0)"
-                
-            }
-        },
-        {
-            "table": "amrs.patient_identifier",
-            "alias": "patient_id",
-            "join": {
-                "type": "inner",
-                "joinCondition": "fbcs.person_id = patient_id.patient_id and (patient_id.voided is null || patient_id.voided = 0)"
-                
-            }
-
-        },
-        {
-            "table": "amrs.location",
-            "alias": "l",
-            "join": {
-                "type": "inner",
-                "joinCondition": "l.location_id = fbcs.location_id"
-                
-            }
-        },
-        {
-            "table": "amrs.person_attribute",
-            "alias": "p",
-            "join": {
-                "type": "left",
-                "joinCondition": "fbcs.person_id = p.person_id and (p.voided is null || p.voided = 0 and (p.person_attribute_type_id = 10))"
-
-            }
-        }
-    ],
-    "columns": [
-        {
-            "type": "simple_column",
-            "alias": "person_id",
-            "column": "fbcs.person_id"
-        },
-        {
-            "type": "derived_column",
-            "alias": "person_name",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "concat(coalesce(patient_name.given_name, ''), ' ', coalesce(patient_name.middle_name, ''), ' ', coalesce(patient_name.family_name, ''))"
-            }
-        },
-        {
-            "type": "simple_column",
-            "alias": "phone_number",
-            "column": "p.value"
-        },    
-        {
-            "type": "derived_column",
-            "alias": "diagnostic_interval",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                        "expression": "(SELECT CONCAT(TIMESTAMPDIFF(DAY, DATE(encounter_datetime), (SELECT date_patient_informed_and_referred_for_management FROM etl.flat_breast_cancer_screening WHERE encounter_type = 145 AND person_id = p.person_id ORDER BY encounter_datetime DESC LIMIT 1)), ' day(s)') FROM etl.flat_breast_cancer_screening WHERE person_id = p.person_id AND encounter_type = 86 and (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) ORDER BY encounter_datetime DESC LIMIT 1)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "identifiers",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "group_concat(distinct patient_id.identifier separator ', ')"
-            }
-        },
-        {
-            "type": "simple_column",
-            "alias": "gender",
-            "column": "fbcs.gender"
-        },
-        {
-            "type": "simple_column",
-            "alias": "age",
-            "column": "fbcs.age"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_id",
-            "column": "fbcs.location_id"
-        },
-        {
-            "type": "derived_column",
-            "alias": "type_of_abnormality",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "case when cur_physical_findings=0 then 'Normal' when cur_physical_findings=1 then 'Mastitis' when cur_physical_findings=2 then 'Breast lumps' when cur_physical_findings=3 then 'Cracked nipple' when cur_physical_findings=4 then 'Others' when cur_physical_findings=5 then 'Mass' when cur_physical_findings=6 then 'Nipple discharge' when cur_physical_findings=7 then 'Breast skin changes' when cur_physical_findings=8 then 'Not done' when cur_physical_findings=9 then 'Abscess breast' when cur_physical_findings=10 then 'Breast engorgement' when cur_physical_findings=11 then 'Abnormal' when cur_physical_findings=12 then 'Calor' when cur_physical_findings=13 then 'Peau Dorange' when cur_physical_findings=14 then 'Unknown' when cur_physical_findings=15 then 'Fine nodularity' when cur_physical_findings=16 then 'Dense nodularity' when cur_physical_findings=17 then 'Skin edema' when cur_physical_findings=18 then 'Nipple areolar change' when cur_physical_findings=19 then 'Muscle tenderness' when cur_physical_findings=20 then 'Benign' else null end"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "screening_mode",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "case when (select screening_mode from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) = 1 and (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'MAMMOGRAM' when (select screening_mode from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) = 2 and (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'CLINICAL BREAST EXAM'when (select screening_mode from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) = 3 and (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'ULTRASOUND, BREAST' else ' - ' end"
-            }
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_uuid",
-            "column": "fbcs.location_uuid"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_name",
-            "column": "l.name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "encounter_datetime",
-            "column": "DATE_FORMAT(fbcs.encounter_datetime, '%Y-%m-%d')"
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "if(cur_physical_findings = 0 or cur_physical_findings is null, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_below_30yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age < 30, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_30_to_40yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age >= 30 and age <= 40, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_41_to_50yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age >= 41 and age <= 50, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_51_to_69yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age >= 51 and age <= 69, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_breast_screening_findings_above_70yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age >= 70, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "if(cur_physical_findings != 0, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_below_30yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "if(cur_physical_findings != 0 and age < 30, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_30_to_40yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "if(cur_physical_findings != 0 and age >= 30 and age <= 40, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_41_to_50yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if(cur_physical_findings != 0 and age >= 41 and age <= 50, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_51_to_69yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if(cur_physical_findings != 0 and age >= 51 and age <= 69, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_breast_screening_findings_above_70yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "if(cur_physical_findings != 0 and age >= 70, 1, null)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "biopsy_results_within_2wks",
-            "expressionType": "case_statement",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "TIMESTAMPDIFF(WEEK, DATE(encounter_datetime), DATE(date_patient_notified_of_biopsy_results)) <= 2",
-                        "value": 1
-                    }
-                ]
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "hiv_status",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "case when hiv_status=1 then 'HIV Negative' when hiv_status=2 then 'HIV Positive' when hiv_status=3 then 'Unknown' else NULL end"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "clients_staged_before_treatment",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "(IF(cancer_staging IN (1 , 2, 3, 4), 1, NULL))"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "procedure_done",
-            "expressionType": "case_statement",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "procedure_done = 1",
-                        "value": "Ultrasound"
-                    },
-                    {
-                        "condition": "procedure_done = 2",
-                        "value": "Mammogram"
-                    },
-                    {
-                        "condition": "procedure_done = 3",
-                        "value": "Core Needle Biopsy"
-                    },
-                    {
-                        "condition": "procedure_done = 4",
-                        "value": "FNA"
-                    },
-                    {
-                        "condition": "procedure_done = 5",
-                        "value": "Surgical biopsy"
-                    },
-                    {
-                        "condition": "procedure_done = 6",
-                        "value": "Incisional biopsy"
-                    }
-                ]
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "diagnosis",
-            "expressionType": "case_statement",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "diagnosis IN (9618 , 6544, 6250, 6243, 2220, 115)",
-                        "value": 1
-                    }
-                ]
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "cancer_stage",
-            "expressionType": "case_statement",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "cancer_staging = 1",
-                        "value": "Stage I"
-                    },
-                    {
-                        "condition": "cancer_staging = 2",
-                        "value": "Stage II"
-                    },
-                    {
-                        "condition": "cancer_staging = 3",
-                        "value": "Stage III"
-                    },
-                    {
-                        "condition": "cancer_staging = 4",
-                        "value": "Stage IV"
-                    }
-                ]
-            }
-        },
-        {
-            "type": "simple_column",
-            "alias": "date_patient_informed_of_results",
-            "column": "(select DATE_FORMAT(date_patient_informed_and_referred_for_management, '%d-%M-%Y') from etl.flat_breast_cancer_screening where encounter_type = 145 and (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) and person_id = p.person_id order by encounter_datetime desc limit 1)"
-        },
-        {
-            "type": "derived_column",
-            "alias": "total_reffered_for_followup",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                        "expression": "if(referrals_ordered = 1, 1, NULL)"
-                       }
-        }
-    ],
-    "filters": {
-        "conditionJoinOperator": "and",
-        "conditions": [
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fbcs.age >= ?",
-                "parameterName": "startAge"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fbcs.age <= ?",
-                "parameterName": "endAge"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "DATE(fbcs.encounter_datetime) >= ?",
-                "parameterName": "startDate"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "DATE(fbcs.encounter_datetime) <= ?",
-                "parameterName": "endDate"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fbcs.encounter_type = 86"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fbcs.location_uuid in ?",
-                "parameterName": "locationUuids"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fbcs.gender in ?",
-                "parameterName": "genders"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fbcs.location_id not in (195)"
-            }
-        ]
+  "name": "breastCancerMonthlySummaryBase",
+  "version": "1.0",
+  "tag": "breast_cancer_monthly_summary_base",
+  "uses": [],
+  "sources": [
+    {
+      "table": "etl.flat_breast_cancer_screening",
+      "alias": "fbcs"
     },
-    "groupBy": {
-        "groupParam": "groupByParam",
-        "columns": [
-            "encounter_id"
-        ]
+    {
+      "table": "amrs.person_name",
+      "alias": "patient_name",
+      "join": {
+        "type": "inner",
+        "joinCondition": "fbcs.person_id = patient_name.person_id and (patient_name.voided is null || patient_name.voided = 0)"
+      }
+    },
+    {
+      "table": "amrs.patient_identifier",
+      "alias": "patient_id",
+      "join": {
+        "type": "inner",
+        "joinCondition": "fbcs.person_id = patient_id.patient_id and (patient_id.voided is null || patient_id.voided = 0)"
+      }
+    },
+    {
+      "table": "amrs.location",
+      "alias": "l",
+      "join": {
+        "type": "inner",
+        "joinCondition": "l.location_id = fbcs.location_id"
+      }
+    },
+    {
+      "table": "amrs.person_attribute",
+      "alias": "p",
+      "join": {
+        "type": "left",
+        "joinCondition": "fbcs.person_id = p.person_id and (p.voided is null || p.voided = 0 and (p.person_attribute_type_id = 10))"
+      }
     }
+  ],
+  "columns": [
+    {
+      "type": "simple_column",
+      "alias": "person_id",
+      "column": "fbcs.person_id"
+    },
+    {
+      "type": "derived_column",
+      "alias": "person_name",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "concat(coalesce(patient_name.given_name, ''), ' ', coalesce(patient_name.middle_name, ''), ' ', coalesce(patient_name.family_name, ''))"
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "phone_number",
+      "column": "p.value"
+    },
+    {
+      "type": "derived_column",
+      "alias": "diagnostic_interval",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "(SELECT CONCAT(TIMESTAMPDIFF(DAY, DATE(encounter_datetime), (SELECT date_patient_informed_and_referred_for_management FROM etl.flat_breast_cancer_screening WHERE encounter_type = 145 AND person_id = p.person_id ORDER BY encounter_datetime DESC LIMIT 1)), ' day(s)') FROM etl.flat_breast_cancer_screening WHERE person_id = p.person_id AND encounter_type = 86 and (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) ORDER BY encounter_datetime DESC LIMIT 1)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "identifiers",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "group_concat(distinct patient_id.identifier separator ', ')"
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "age",
+      "column": "fbcs.age"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_id",
+      "column": "fbcs.location_id"
+    },
+    {
+      "type": "derived_column",
+      "alias": "type_of_abnormality",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "case when cur_physical_findings=0 then 'Normal' when cur_physical_findings=1 then 'Mastitis' when cur_physical_findings=2 then 'Breast lumps' when cur_physical_findings=3 then 'Cracked nipple' when cur_physical_findings=4 then 'Others' when cur_physical_findings=5 then 'Mass' when cur_physical_findings=6 then 'Nipple discharge' when cur_physical_findings=7 then 'Breast skin changes' when cur_physical_findings=8 then 'Not done' when cur_physical_findings=9 then 'Abscess breast' when cur_physical_findings=10 then 'Breast engorgement' when cur_physical_findings=11 then 'Abnormal' when cur_physical_findings=12 then 'Calor' when cur_physical_findings=13 then 'Peau Dorange' when cur_physical_findings=14 then 'Unknown' when cur_physical_findings=15 then 'Fine nodularity' when cur_physical_findings=16 then 'Dense nodularity' when cur_physical_findings=17 then 'Skin edema' when cur_physical_findings=18 then 'Nipple areolar change' when cur_physical_findings=19 then 'Muscle tenderness' when cur_physical_findings=20 then 'Benign' else null end"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "screening_mode",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "case when (select screening_mode from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) = 1 AND (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'Mammogram' when (select screening_mode from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) = 2 and (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'Clinical breast exam' when (select screening_mode from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) = 3 and (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'Ultrasound, breast' else null end"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "lymph_nodes_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.lymph_nodes_findings = 1",
+            "value": "Normal"
+          },
+          {
+            "condition": "fbcs.lymph_nodes_findings = 2",
+            "value": "Lymphadenopathy"
+          },
+          {
+            "condition": "lymph_nodes_findings = 3",
+            "value": "Fixed"
+          },
+          {
+            "condition": "fbcs.lymph_nodes_findings = 4",
+            "value": "Mobile"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "patient_education",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.patient_education = 1",
+            "value": "Annual screening"
+          },
+          {
+            "condition": "fbcs.patient_education = 2",
+            "value": "Follow-up"
+          },
+          {
+            "condition": "fbcs.patient_education = 3",
+            "value": "Self examination"
+          },
+          {
+            "condition": "fbcs.patient_education = 4",
+            "value": "Other (Non-coded)"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "referral_ordered",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.referrals_ordered = 1",
+            "value": "None"
+          },
+          {
+            "condition": "fbcs.referrals_ordered = 2",
+            "value": "Clinician"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "breast_complaints_three_months",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.breast_complaints_3months = 1",
+            "value": "Asymptomatic"
+          },
+          {
+            "condition": "fbcs.breast_complaints_3months = 2",
+            "value": "Symptomatic"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "breast_mass_location",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.breast_mass_location = 1",
+            "value": "Bilateral"
+          },
+          {
+            "condition": "fbcs.breast_mass_location = 2",
+            "value": "Left"
+          },
+          {
+            "condition": "fbcs.breast_mass_location = 3",
+            "value": "Right"
+          },
+          {
+            "condition": "fbcs.breast_mass_location = 4",
+            "value": "Upper inner quadrant"
+          },
+          {
+            "condition": "fbcs.breast_mass_location = 5",
+            "value": "Lower inner quadrant"
+          },
+          {
+            "condition": "fbcs.breast_mass_location = 6",
+            "value": "Upper outer quadrant"
+          },
+          {
+            "condition": "fbcs.breast_mass_location = 7",
+            "value": "Cyclic"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "nipple_discharge_location",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.nipple_discharge_location = 1",
+            "value": "Left"
+          },
+          {
+            "condition": "fbcs.nipple_discharge_location = 2",
+            "value": "Right"
+          },
+          {
+            "condition": "fbcs.nipple_discharge_location = 3",
+            "value": "Cyclic"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "nipple_retraction_location",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.nipple_retraction_location = 1",
+            "value": "Left"
+          },
+          {
+            "condition": "fbcs.nipple_retraction_location = 2",
+            "value": "Right"
+          },
+          {
+            "condition": "fbcs.nipple_retraction_location = 3",
+            "value": "Cyclic"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "breast_erythrema_location",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.breast_erythrema_location = 1",
+            "value": "Left"
+          },
+          {
+            "condition": "fbcs.breast_erythrema_location = 2",
+            "value": "Right"
+          },
+          {
+            "condition": "fbcs.breast_erythrema_location = 3",
+            "value": "Cyclic"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "breast_rash_location",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.breast_rash_location = 1",
+            "value": "Left"
+          },
+          {
+            "condition": "fbcs.breast_rash_location = 2",
+            "value": "Right"
+          },
+          {
+            "condition": "fbcs.breast_rash_location = 3",
+            "value": "Cyclic"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "breast_pain_location",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.breast_pain_location = 1",
+            "value": "Left"
+          },
+          {
+            "condition": "fbcs.breast_pain_location = 2",
+            "value": "Right"
+          },
+          {
+            "condition": "fbcs.breast_pain_location = 3",
+            "value": "Cyclic"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "other_changes_location",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "other_changes_location = 1",
+            "value": "Left"
+          },
+          {
+            "condition": "other_changes_location = 2",
+            "value": "Right"
+          },
+          {
+            "condition": "other_changes_location = 3",
+            "value": "Cyclic"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "history_of_mammogram",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.history_of_mammogram = 0",
+            "value": "No"
+          },
+          {
+            "condition": "fbcs.history_of_mammogram = 1",
+            "value": "Yes"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "mammogram_results",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.mammogram_results = 1",
+            "value": "Normal"
+          },
+          {
+            "condition": "fbcs.mammogram_results = 2",
+            "value": "Abnormal"
+          },
+          {
+            "condition": "fbcs.mammogram_results = 3",
+            "value": "Not done"
+          },
+          {
+            "condition": "mammogram_results = 4",
+            "value": "Indeterminate"
+          },
+          {
+            "condition": "fbcs.mammogram_results = 5",
+            "value": "Completed"
+          },
+          {
+            "condition": "fbcs.mammogram_results = 6",
+            "value": "Unknown"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "breast_ultrasound_history",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.breast_ultrasound_history = 0",
+            "value": "No"
+          },
+          {
+            "condition": "fbcs.breast_ultrasound_history = 1",
+            "value": "Yes"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "breast_ultrasound_result",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.breast_ultrasound_result = 1",
+            "value": "Normal"
+          },
+          {
+            "condition": "fbcs.breast_ultrasound_result = 2",
+            "value": "Abnormal"
+          },
+          {
+            "condition": "fbcs.breast_ultrasound_result = 3",
+            "value": "Unknown"
+          },
+          {
+            "condition": "fbcs.breast_ultrasound_result = 4",
+            "value": "Not done"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "history_of_breast_biopsy",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.history_of_breast_biopsy = 0",
+            "value": "No"
+          },
+          {
+            "condition": "fbcs.history_of_breast_biopsy = 1",
+            "value": "Yes"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "breast_biopsy_results",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.breast_biopsy_results = 1",
+            "value": "Normal"
+          },
+          {
+            "condition": "fbcs.breast_biopsy_results = 2",
+            "value": "Abnormal"
+          },
+          {
+            "condition": "fbcs.breast_biopsy_results = 3",
+            "value": "Unknown"
+          },
+          {
+            "condition": "fbcs.breast_biopsy_results = 4",
+            "value": "Benign"
+          },
+          {
+            "condition": "fbcs.breast_biopsy_results = 5",
+            "value": "Malignant"
+          },
+          {
+            "condition": "fbcs.breast_biopsy_results = 6",
+            "value": "Not done"
+          }
+        ]
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "number_of_biopsies",
+      "column": "number_of_biopsies"
+    },
+    {
+      "type": "derived_column",
+      "alias": "biopsy_type",
+      "expressionType": "simpleExpression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "fbcs.biopsy_type = 1",
+            "value": "Core needle biopsy"
+          },
+          {
+            "condition": "fbcs.biopsy_type = 2",
+            "value": "Excisional / surgical biopsy"
+          },
+          {
+            "condition": "fbcs.biopsy_type = 3",
+            "value": "Skin punch biopsy"
+          },
+          {
+            "condition": "fbcs.biopsy_type = 4",
+            "value": "Bone marrow biopsy"
+          },
+          {
+            "condition": "fbcs.biopsy_type = 5",
+            "value": "Fine needle aspiration"
+          },
+          {
+            "condition": "fbcs.biopsy_type = 6",
+            "value": "Breast biopsy"
+          },
+          {
+            "condition": "fbcs.biopsy_type = 7",
+            "value": "Ultrasound guided biopsy"
+          },
+          {
+            "condition": "fbcs.biopsy_type = 8",
+            "value": "CT Scan guided biopsy"
+          }
+        ]
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_uuid",
+      "column": "fbcs.location_uuid"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_name",
+      "column": "l.name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "encounter_datetime",
+      "column": "DATE_FORMAT(fbcs.encounter_datetime, '%Y-%m-%d')"
+    },
+    {
+      "type": "derived_column",
+      "alias": "male_patients",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.gender = 'M', 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "female_patients",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.gender = 'F', 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 1, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status_unknown",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 3, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 2, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(cur_physical_findings = 0 or cur_physical_findings is null, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age < 30, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age >= 30 and age <= 40, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age >= 41 and age <= 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age >= 51 and age <= 69, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age >= 70, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(cur_physical_findings != 0, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(cur_physical_findings != 0 and age < 30, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(cur_physical_findings != 0 and age >= 30 and age <= 40, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(cur_physical_findings != 0 and age >= 41 and age <= 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(cur_physical_findings != 0 and age >= 51 and age <= 69, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(cur_physical_findings != 0 and age >= 70, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "biopsy_results_within_2wks",
+      "expressionType": "case_statement",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "TIMESTAMPDIFF(WEEK, DATE(encounter_datetime), DATE(date_patient_notified_of_biopsy_results)) <= 2",
+            "value": 1
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "case when hiv_status=1 then 'HIV Negative' when hiv_status=2 then 'HIV Positive' when hiv_status=3 then 'Unknown' else NULL end"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "clients_staged_before_treatment",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "(IF(cancer_staging IN (1 , 2, 3, 4), 1, NULL))"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "procedure_done",
+      "expressionType": "case_statement",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "procedure_done = 1",
+            "value": "Ultrasound"
+          },
+          {
+            "condition": "procedure_done = 2",
+            "value": "Mammogram"
+          },
+          {
+            "condition": "procedure_done = 3",
+            "value": "Core Needle Biopsy"
+          },
+          {
+            "condition": "procedure_done = 4",
+            "value": "FNA"
+          },
+          {
+            "condition": "procedure_done = 5",
+            "value": "Surgical biopsy"
+          },
+          {
+            "condition": "procedure_done = 6",
+            "value": "Incisional biopsy"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "diagnosis",
+      "expressionType": "case_statement",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "diagnosis IN (9618 , 6544, 6250, 6243, 2220, 115)",
+            "value": 1
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "cancer_stage",
+      "expressionType": "case_statement",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "cancer_staging = 1",
+            "value": "Stage I"
+          },
+          {
+            "condition": "cancer_staging = 2",
+            "value": "Stage II"
+          },
+          {
+            "condition": "cancer_staging = 3",
+            "value": "Stage III"
+          },
+          {
+            "condition": "cancer_staging = 4",
+            "value": "Stage IV"
+          }
+        ]
+      }
+    }
+  ],
+  "filters": {
+    "conditionJoinOperator": "and",
+    "conditions": [
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fbcs.age >= ?",
+        "parameterName": "startAge"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fbcs.age <= ?",
+        "parameterName": "endAge"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "DATE(fbcs.encounter_datetime) >= ?",
+        "parameterName": "startDate"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "DATE(fbcs.encounter_datetime) <= ?",
+        "parameterName": "endDate"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fbcs.encounter_type = 86"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fbcs.location_uuid in ?",
+        "parameterName": "locationUuids"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fbcs.gender in ?",
+        "parameterName": "genders"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fbcs.location_id not in (195)"
+      }
+    ]
+  },
+  "groupBy": {
+    "groupParam": "groupByParam",
+    "columns": [
+      "encounter_id"
+    ]
+  }
 }

--- a/app/reporting-framework/json-reports/cervical-cancer-daily-screening-summary-aggregate.json
+++ b/app/reporting-framework/json-reports/cervical-cancer-daily-screening-summary-aggregate.json
@@ -1,101 +1,205 @@
 {
   "name": "cervicalCancerDailyReportAggregate",
   "version": "1.0",
-	"tag": "",
-	"description": "",
+  "tag": "",
+  "description": "",
   "uses": [{
-  	"name": "cervicalCancerMonthlyReportBase",
-		"version": "1.0",
-		"type": "dataset_def"
+    "name": "cervicalCancerMonthlyReportBase",
+    "version": "1.0",
+    "type": "dataset_def"
   }],
   "sources": [{
-		"dataSet": "cervicalCancerMonthlyReportBase",
-		"alias": "t1"
+    "dataSet": "cervicalCancerMonthlyReportBase",
+    "alias": "t1"
   }],
   "columns": [{
-		"type": "simple_column",
-		"alias": "location_id",
-		"column": "t1.location_id"
-	},
-	{
-		"type": "simple_column",
-		"alias": "location_name",
-		"column": "location_name"
-	},
-	{
-		"type": "simple_column",
-		"alias": "location_uuid",
-		"column": "location_uuid"
-	},
-	{
-		"type": "derived_column",
-		"alias": "encounter_datetime",
-		"expressionType": "simple_expression",
-		"expressionOptions": {
-			"expression": "date_format(t1.encounter_datetime,'%d-%m-%Y')"
-		}
-	},
-	{
-		"type": "derived_column",
-		"alias": "total_cervical_screened",
-		"expressionType": "simple_expression",
-		"expressionOptions": {
-				"expression": "count(person_id)"
-		}
-	},
-	{
-		"type": "derived_column",
-		"alias": "normal_cervical_screening",
-		"expressionType": "simple_expression",
-		"expressionOptions": {
-				"expression": "count(normal_cervical_screening)"
-		}
-	},
-	{
-		"type": "derived_column",
-		"alias": "abnormal_cervical_screening",
-		"expressionType": "simple_expression",
-		"expressionOptions": {
-				"expression": "count(abnormal_cervical_screening)"
-		}
-	},
-	{
-		"type": "derived_column",
-		"alias": "normal_cervical_call_rate%",
-		"expressionType": "simple_expression",
-		"expressionOptions": {
-				"expression": "ROUND(count(normal_cervical_screening)/count(person_id) *100,2)"
-		}
-	},
-	{
-		"type": "derived_column",
-		"alias": "abnormal_cervical_call_rate%",
-		"expressionType": "simple_expression",
-		"expressionOptions": {
-				"expression": "ROUND(count(abnormal_cervical_screening)/count(person_id) *100,2)"
-		}
-	}
+      "type": "simple_column",
+      "alias": "location_id",
+      "column": "t1.location_id"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_name",
+      "column": "location_name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_uuid",
+      "column": "location_uuid"
+    },
+    {
+      "type": "derived_column",
+      "alias": "encounter_datetime",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "date_format(t1.encounter_datetime,'%d-%m-%Y')"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "total_cervical_screened",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(person_id)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_findings)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_findings)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_cervical_call_rate%",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "ROUND(count(normal_findings)/count(person_id) *100,2)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_cervical_call_rate%",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "ROUND(count(abnormal_findings)/count(person_id) *100,2)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status_unknown",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_status_unknown)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_below_30yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_below_30yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_30_to_40yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_30_to_40yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_41_to_50yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_41_to_50yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_51_to_69yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_51_to_69yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_above_70yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_above_70yrs)"
+      }
+    }
   ],
   "groupBy": {
-		"groupParam": "groupByParam",
-		"columns": [
-				"location_id",
-				"DATE(t1.encounter_datetime)"
-		],
-		"excludeParam": "excludeParam"
+    "groupParam": "groupByParam",
+    "columns": [
+      "location_id",
+      "DATE(t1.encounter_datetime)"
+    ],
+    "excludeParam": "excludeParam"
   },
   "dynamicJsonQueryGenerationDirectives": {
-		"patientListGenerator": {
-			"useTemplate": "patient-list-template",
-			"useTemplateVersion": "1.0",
-			"generatingDirectives": {
-				"joinDirectives": {
-					"joinType": "INNER",
-					"joinCondition": "<<base_column>> = <<template_column>>",
-					"baseColumn": "person_id",
-					"templateColumn": "person_id"
-				}
-			}
-		}
+    "patientListGenerator": {
+      "useTemplate": "patient-list-template",
+      "useTemplateVersion": "1.0",
+      "generatingDirectives": {
+        "joinDirectives": {
+          "joinType": "INNER",
+          "joinCondition": "<<base_column>> = <<template_column>>",
+          "baseColumn": "person_id",
+          "templateColumn": "person_id"
+        }
+      }
+    }
   }
 }

--- a/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-aggregate.json
+++ b/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-aggregate.json
@@ -1,182 +1,211 @@
 {
-    "name": "cervicalCancerMonthlyReportAggregate",
-    "version": "1.0",
-    "tag": "",
-    "description": "",
-    "uses": [{
-        "name": "cervicalCancerMonthlyReportBase",
-        "version": "1.0",
-        "type": "dataset_def"
-    }],
-    "sources": [{
-        "dataSet": "cervicalCancerMonthlyReportBase",
-        "alias": "t1"
-    }],
-    "columns": [{
-            "type": "simple_column",
-            "alias": "location_id",
-            "column": "t1.location_id"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_name",
-            "column": "location_name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_uuid",
-            "column": "location_uuid"
-        },
-        {
-            "type": "derived_column",
-            "alias": "encounter_datetime",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "date_format(t1.encounter_datetime,'%m-%Y')"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "total_cervical_screened",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(person_id)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_call_rate%",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "ROUND(count(normal_cervical_screening)/count(person_id) *100,2)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_call_rate%",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "ROUND(count(abnormal_cervical_screening)/count(person_id) *100,2)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_cervical_screening)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_below_30yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_cervical_screening_below_30yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_30_to_40yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_cervical_screening_30_to_40yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_41_to_50yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_cervical_screening_41_to_50yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_51_to_69yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_cervical_screening_51_to_69yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_above_70yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(normal_cervical_screening_above_70yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_cervical_screening)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_below_30yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_cervical_screening_below_30yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_30_to_40yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_cervical_screening_30_to_40yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_41_to_50yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_cervical_screening_41_to_50yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_51_to_69yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_cervical_screening_51_to_69yrs)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_above_70yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "count(abnormal_cervical_screening_above_70yrs)"
-            }
-        }
-    ],
-    "groupBy": {
-        "groupParam": "groupByParam",
-        "columns": [
-            "location_id",
-            "year(encounter_datetime)",
-            "month(encounter_datetime)"
-        ],
-        "excludeParam": "excludeParam"
-    },
-    "dynamicJsonQueryGenerationDirectives": {
-        "patientListGenerator": {
-            "useTemplate": "patient-list-template",
-            "useTemplateVersion": "1.0",
-            "generatingDirectives": {
-                "joinDirectives": {
-                    "joinType": "INNER",
-                    "joinCondition": "<<base_column>> = <<template_column>>",
-                    "baseColumn": "person_id",
-                    "templateColumn": "person_id"
-                }
-            }
-        }
+  "name": "cervicalCancerMonthlyReportAggregate",
+  "version": "1.0",
+  "tag": "",
+  "description": "",
+  "uses": [
+    {
+      "name": "cervicalCancerMonthlyReportBase",
+      "version": "1.0",
+      "type": "dataset_def"
     }
+  ],
+  "sources": [
+    {
+      "dataSet": "cervicalCancerMonthlyReportBase",
+      "alias": "t1"
+    }
+  ],
+  "columns": [
+    {
+      "type": "simple_column",
+      "alias": "location_id",
+      "column": "t1.location_id"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_name",
+      "column": "location_name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_uuid",
+      "column": "location_uuid"
+    },
+    {
+      "type": "derived_column",
+      "alias": "encounter_datetime",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "date_format(t1.encounter_datetime,'%m-%Y')"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "total_cervical_screened",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(person_id)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_findings)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_findings)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_cervical_call_rate%",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "ROUND(count(normal_findings)/count(person_id) *100,2)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_cervical_call_rate%",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "ROUND(count(abnormal_findings)/count(person_id) *100,2)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status_unknown",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_status_unknown)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_below_30yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_below_30yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_30_to_40yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_30_to_40yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_41_to_50yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_41_to_50yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_51_to_69yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_51_to_69yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_above_70yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_above_70yrs)"
+      }
+    }
+  ],
+  "groupBy": {
+    "groupParam": "groupByParam",
+    "columns": [
+      "location_id",
+      "year(encounter_datetime)",
+      "month(encounter_datetime)"
+    ],
+    "excludeParam": "excludeParam"
+  },
+  "dynamicJsonQueryGenerationDirectives": {
+    "patientListGenerator": {
+      "useTemplate": "patient-list-template",
+      "useTemplateVersion": "1.0",
+      "generatingDirectives": {
+        "joinDirectives": {
+          "joinType": "INNER",
+          "joinCondition": "<<base_column>> = <<template_column>>",
+          "baseColumn": "person_id",
+          "templateColumn": "person_id"
+        }
+      }
+    }
+  }
 }

--- a/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-base.json
+++ b/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-base.json
@@ -1,374 +1,567 @@
 {
-    "name": "cervicalCancerMonthlyReportBase",
-    "version": "1.0",
-    "tag": "",
-    "uses": [],
-    "sources": [{
-            "table": "etl.flat_cervical_cancer_screening",
-            "alias": "fccs"
-        },
-        {
-            "table": "amrs.person_name",
-            "alias": "p2",
-            "join": {
-                "type": "INNER",
-                "joinCondition": "fccs.person_id = p2.person_id AND (p2.voided is null || p2.voided = 0)"
-            }
-        },
-        {
-            "table": "amrs.patient_identifier",
-            "alias": "p3",
-            "join": {
-                "type": "LEFT OUTER",
-                "joinCondition": "fccs.person_id = p3.patient_id AND (p3.voided is null || p3.voided = 0)"
-            }
-        },
-        {
-            "table": "amrs.person",
-            "alias": "p5",
-            "join": {
-                "type": "INNER",
-                "joinCondition": "fccs.person_id = p5.person_id AND (p5.voided is null || p5.voided = 0)"
-            }
-        },
-        {
-            "table": "amrs.location",
-            "alias": "l",
-            "join": {
-                "type": "INNER",
-                "joinCondition": "l.location_id = fccs.location_id"
-            }
-        },
-        {
-            "table": "amrs.person_attribute",
-            "alias": "p4",
-            "join": {
-                "type": "LEFT",
-                "joinCondition": "fccs.person_id = p4.person_id AND (p4.voided is null|| p4.voided = 0 and (p4.person_attribute_type_id =10))"
-            }
-        }
-    ],
-    "columns": [
-        {
-            "type": "simple_column",
-            "alias": "person_id",
-            "column": "fccs.person_id"
-        },
-        {
-            "type": "derived_column",
-            "alias": "person_name",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "CONCAT(COALESCE(p2.given_name, ''), ' ', COALESCE(p2.middle_name, ''), ' ', COALESCE(p2.family_name, ''))"
-            }
-        },
-        {
-            "type": "simple_column",
-            "alias": "phone_number",
-            "column": "p4.value"
-        },
-        {
-            "type": "derived_column",
-            "alias": "identifiers",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "GROUP_CONCAT(DISTINCT p3.identifier SEPARATOR ', ')"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "type_of_abnormality",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "cur_via_result = 1",
-                        "value": "Normal"
-                    },
-                    {
-                        "condition": "cur_via_result = 2",
-                        "value": "Acetowhite Lesion"
-                    },
-                    {
-                        "condition": "cur_via_result = 3",
-                        "value": "Friable Tissue"
-                    },
-                    {
-                        "condition": "cur_via_result = 4",
-                        "value": "Atypical Blood Vessels"
-                    },
-                    {
-                        "condition": "cur_via_result = 5",
-                        "value": "Ulcer"
-                    },
-                    {
-                        "condition": "cur_via_result = 6",
-                        "value": "Punctuated Capillaries"
-                    },
-                    {
-                        "condition": "cur_via_result = 7",
-                        "value": "Dysfunctional Uterine Bleeding"
-                    },
-                    {
-                        "condition": "cur_via_result = 8",
-                        "value": "Pallor"
-                    },
-                    {
-                        "condition": "cur_via_result = 9",
-                        "value": "Oysterwhite Lesion"
-                    },
-                    {
-                        "condition": "cur_via_result = 10",
-                        "value": "Bright White Lesion"
-                    },
-                    {
-                        "condition": "cur_via_result = 11",
-                        "value": "Dysfunctional Uterine Bleeding"
-                    }
-                ]
-            }
-        },
-        {
-            "type": "simple_column",
-            "alias": "age",
-            "column": "fccs.age"
-        },
-        {
-            "type": "simple_column",
-            "alias": "gender",
-            "column": "p5.gender"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_id",
-            "column": "fccs.location_id"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_uuid",
-            "column": "fccs.location_uuid"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_name",
-            "column": "l.name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "encounter_datetime",
-            "column": "DATE_FORMAT(fccs.encounter_datetime, '%Y-%m-%d')"
-        },
-        {
-            "type": "derived_column",
-            "alias": "hiv_status",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "case when hiv_status=1 then 'HIV Negative' when hiv_status=2 then 'HIV Positive' when hiv_status=3 then 'Unknown' else NULL end"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if(fccs.cur_via_result != 1, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_below_30yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if(fccs.cur_via_result != 1 and age < 30, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_30_to_40yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if(fccs.cur_via_result != 1 and age >= 30 and age <= 40, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_41_to_50yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if(fccs.cur_via_result != 1 and age >= 41 and age <= 50, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_51_to_69yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if(fccs.cur_via_result != 1 and  age >= 51 and age <= 69, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "abnormal_cervical_screening_above_70yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if(fccs.cur_via_result != 1 and age >= 70, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if(fccs.cur_via_result =1 or fccs.cur_via_result is null,1,null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_below_30yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age < 30, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_30_to_40yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age >= 30 and age <= 40, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_41_to_50yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age >= 41 and age <= 50, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_51_to_69yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and  age >= 51 and age <= 69, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "normal_cervical_screening_above_70yrs",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age >= 70, 1, null)"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "cancer_stage",
-            "expressionType": "case_statement",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "cancer_staging = 1",
-                        "value": "Stage I"
-                    },
-                    {
-                        "condition": "cancer_staging = 2",
-                        "value": "Stage II"
-                    },
-                    {
-                        "condition": "cancer_staging = 3",
-                        "value": "stage III"
-                    },
-                    {
-                        "condition": "cancer_staging = 4",
-                        "value": "Stage IV"
-                    }
-                ]
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "clients_staged_before_treatment",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-            "expression": "(if(cancer_staging in (1,2,3,4),1,null))"
-                       }
-        },
-        {
-            "type": "simple_column",
-            "alias": "date_patient_informed_of_results",
-            "column": "(select DATE_FORMAT(date_patient_informed_referred, '%d-%M-%Y') from etl.flat_cervical_cancer_screening where encounter_type = 147 and (select date_patient_informed_referred from etl.flat_cervical_cancer_screening where encounter_type = 147 and person_id = p2.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_cervical_cancer_screening where encounter_type = 69 and person_id = p2.person_id order by encounter_datetime desc limit 1) and person_id = p2.person_id order by encounter_datetime desc limit 1)"
-        },
-        {
-            "type": "derived_column",
-            "alias": "diagnostic_interval",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                        "expression": "(SELECT CONCAT(TIMESTAMPDIFF(DAY, DATE(encounter_datetime), (SELECT date_patient_informed_referred FROM etl.flat_cervical_cancer_screening WHERE encounter_type = 147 AND person_id = p2.person_id ORDER BY encounter_datetime DESC LIMIT 1)), ' day(s)') FROM etl.flat_cervical_cancer_screening WHERE person_id = p2.person_id AND encounter_type = 69 and (select date_patient_informed_referred from etl.flat_cervical_cancer_screening where encounter_type = 147 and person_id = p2.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_cervical_cancer_screening where encounter_type = 69 and person_id = p2.person_id order by encounter_datetime desc limit 1) ORDER BY encounter_datetime DESC LIMIT 1)"
-                       }
-        },
-        {
-            "type": "derived_column",
-            "alias": "biopsy_results_within_2wks",
-            "expressionType": "case_statement",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "TIMESTAMPDIFF(day, DATE(fccs.encounter_datetime), DATE(prior_biopsy_result_date)) <= 14",
-                        "value": 1
-                    }
-                ]
-            }
-        }
-    ],
-    "filters": {
-        "conditionJoinOperator": "and",
-        "conditions": [
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fccs.age >= ?",
-                "parameterName": "startAge"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fccs.age <= ?",
-                "parameterName": "endAge"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "DATE(fccs.encounter_datetime) >= ?",
-                "parameterName": "startDate"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "DATE(fccs.encounter_datetime) <= ?",
-                "parameterName": "endDate"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fccs.encounter_type = 69"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fccs.location_uuid in ?",
-                "parameterName": "locationUuids"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "p5.gender in ?",
-                "parameterName": "genders"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "fccs.location_id not in (195)"
-            }
-        ]
+  "name": "cervicalCancerMonthlyReportBase",
+  "version": "1.0",
+  "tag": "",
+  "uses": [],
+  "sources": [
+    {
+      "table": "etl.flat_cervical_cancer_screening",
+      "alias": "fccs"
     },
-    "groupBy": {
-        "groupParam": "groupByParam",
-        "columns": [
-            "fccs.encounter_id"
-        ]
+    {
+      "table": "amrs.person_name",
+      "alias": "p2",
+      "join": {
+        "type": "INNER",
+        "joinCondition": "fccs.person_id = p2.person_id AND (p2.voided is null || p2.voided = 0)"
+      }
+    },
+    {
+      "table": "amrs.patient_identifier",
+      "alias": "p3",
+      "join": {
+        "type": "LEFT OUTER",
+        "joinCondition": "fccs.person_id = p3.patient_id AND (p3.voided is null || p3.voided = 0)"
+      }
+    },
+    {
+      "table": "amrs.person",
+      "alias": "p5",
+      "join": {
+        "type": "INNER",
+        "joinCondition": "fccs.person_id = p5.person_id AND (p5.voided is null || p5.voided = 0)"
+      }
+    },
+    {
+      "table": "amrs.location",
+      "alias": "l",
+      "join": {
+        "type": "INNER",
+        "joinCondition": "l.location_id = fccs.location_id"
+      }
+    },
+    {
+      "table": "amrs.person_attribute",
+      "alias": "p4",
+      "join": {
+        "type": "LEFT",
+        "joinCondition": "fccs.person_id = p4.person_id AND (p4.voided is null|| p4.voided = 0 and (p4.person_attribute_type_id =10))"
+      }
     }
+  ],
+  "columns": [
+    {
+      "type": "simple_column",
+      "alias": "person_id",
+      "column": "fccs.person_id"
+    },
+    {
+      "type": "derived_column",
+      "alias": "person_name",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "CONCAT(COALESCE(p2.given_name, ''), ' ', COALESCE(p2.middle_name, ''), ' ', COALESCE(p2.family_name, ''))"
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "phone_number",
+      "column": "p4.value"
+    },
+    {
+      "type": "derived_column",
+      "alias": "identifiers",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "GROUP_CONCAT(DISTINCT p3.identifier SEPARATOR ', ')"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "type_of_abnormality",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "cur_via_result = 1",
+            "value": "Normal"
+          },
+          {
+            "condition": "cur_via_result = 2",
+            "value": "Acetowhite Lesion"
+          },
+          {
+            "condition": "cur_via_result = 3",
+            "value": "Friable Tissue"
+          },
+          {
+            "condition": "cur_via_result = 4",
+            "value": "Atypical Blood Vessels"
+          },
+          {
+            "condition": "cur_via_result = 5",
+            "value": "Ulcer"
+          },
+          {
+            "condition": "cur_via_result = 6",
+            "value": "Punctuated Capillaries"
+          },
+          {
+            "condition": "cur_via_result = 7",
+            "value": "Dysfunctional Uterine Bleeding"
+          },
+          {
+            "condition": "cur_via_result = 8",
+            "value": "Pallor"
+          },
+          {
+            "condition": "cur_via_result = 9",
+            "value": "Oysterwhite Lesion"
+          },
+          {
+            "condition": "cur_via_result = 10",
+            "value": "Bright White Lesion"
+          },
+          {
+            "condition": "cur_via_result = 11",
+            "value": "Dysfunctional Uterine Bleeding"
+          }
+        ]
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "age",
+      "column": "fccs.age"
+    },
+    {
+      "type": "simple_column",
+      "alias": "gender",
+      "column": "p5.gender"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_id",
+      "column": "fccs.location_id"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_uuid",
+      "column": "fccs.location_uuid"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_name",
+      "column": "l.name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "encounter_datetime",
+      "column": "DATE_FORMAT(fccs.encounter_datetime, '%Y-%m-%d')"
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "case when hiv_status=1 then 'HIV Negative' when hiv_status=2 then 'HIV Positive' when hiv_status=3 then 'Unknown' else NULL end"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "prior_via_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "CASE WHEN prior_via_done = 1 THEN 'Yes' WHEN prior_via_done = 2 THEN 'No' ELSE NULL END"
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "prior_via_date",
+      "column": "fccs.prior_via_date"
+    },
+    {
+      "type": "derived_column",
+      "alias": "prior_via_result",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "CASE WHEN prior_via_result = 1 THEN 'Positive' WHEN prior_via_result = 2 THEN 'Negative' ELSE NULL END"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "visual_impression_cervix",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "visual_impression_cervix = 1",
+            "value": "Normal"
+          },
+          {
+            "condition": "visual_impression_cervix = 2",
+            "value": "Positive VIA with Aceto white area"
+          },
+          {
+            "condition": "visual_impression_cervix = 3",
+            "value": "Positive VIA with suspicious lesion"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "visual_impression_vagina",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "visual_impression_vagina = 1",
+            "value": "Normal"
+          },
+          {
+            "condition": "visual_impression_vagina = 2",
+            "value": "Warts, Genital"
+          },
+          {
+            "condition": "visual_impression_vagina = 3",
+            "value": "Suspicious of cancer, vaginal lesion"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "visual_impression_vulva",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "visual_impression_vulva = 1",
+            "value": "Normal"
+          },
+          {
+            "condition": "visual_impression_vulva = 2",
+            "value": "Warts, Genital"
+          },
+          {
+            "condition": "visual_impression_vulva = 3",
+            "value": "Suspicious of cancer, vulva lesion"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "via_procedure_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "via_procedure_done = 1",
+            "value": "None"
+          },
+          {
+            "condition": "via_procedure_done = 2",
+            "value": "Excisional / Surgical biopsy"
+          },
+          {
+            "condition": "via_procedure_done = 3",
+            "value": "Cryotherapy"
+          },
+          {
+            "condition": "via_procedure_done = 4",
+            "value": "LEEP"
+          },
+          {
+            "condition": "via_procedure_done = 5",
+            "value": "Cervical Polypectomy"
+          },
+          {
+            "condition": "via_procedure_done = 6",
+            "value": "Core Needle Biopsy"
+          },
+          {
+            "condition": "via_procedure_done = 7",
+            "value": "Papanicolaou Smear"
+          },
+          {
+            "condition": "via_procedure_done = 8",
+            "value": "Other (Non-coded)"
+          }
+        ]
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "other_via_procedure_done",
+      "column": "other_via_procedure_done"
+    },
+    {
+      "type": "derived_column",
+      "alias": "via_management_plan",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "via_management_plan = 1",
+            "value": "Return for result"
+          },
+          {
+            "condition": "via_management_plan = 2",
+            "value": "VIA follow-up in 3 months"
+          },
+          {
+            "condition": "via_management_plan = 3",
+            "value": "Complete VIA in 3 years"
+          },
+          {
+            "condition": "via_management_plan = 4",
+            "value": "Colposcopy"
+          },
+          {
+            "condition": "via_management_plan = 5",
+            "value": "Gynecologic oncology services"
+          },
+          {
+            "condition": "via_management_plan = 6",
+            "value": "Other (Non-coded)"
+          }
+        ]
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "via_rtc_date",
+      "column": "DATE_FORMAT(fccs.via_rtc_date, '%Y-%m-%d')"
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 1, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status_unknown",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 3, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 2, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.cur_via_result != 1, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.cur_via_result != 1 and age < 30, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.cur_via_result != 1 and age >= 30 and age <= 40, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.cur_via_result != 1 and age >= 41 and age <= 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.cur_via_result != 1 and  age >= 51 and age <= 69, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.cur_via_result != 1 and age >= 70, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.cur_via_result =1 or fccs.cur_via_result is null,1,null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age < 30, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age >= 30 and age <= 40, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age >= 41 and age <= 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and  age >= 51 and age <= 69, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age >= 70, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "cancer_stage",
+      "expressionType": "case_statement",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "cancer_staging = 1",
+            "value": "Stage I"
+          },
+          {
+            "condition": "cancer_staging = 2",
+            "value": "Stage II"
+          },
+          {
+            "condition": "cancer_staging = 3",
+            "value": "stage III"
+          },
+          {
+            "condition": "cancer_staging = 4",
+            "value": "Stage IV"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "clients_staged_before_treatment",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "(if(cancer_staging in (1,2,3,4),1,null))"
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "date_patient_informed_of_results",
+      "column": "(select DATE_FORMAT(date_patient_informed_referred, '%d-%M-%Y') from etl.flat_cervical_cancer_screening where encounter_type = 147 and (select date_patient_informed_referred from etl.flat_cervical_cancer_screening where encounter_type = 147 and person_id = p2.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_cervical_cancer_screening where encounter_type = 69 and person_id = p2.person_id order by encounter_datetime desc limit 1) and person_id = p2.person_id order by encounter_datetime desc limit 1)"
+    },
+    {
+      "type": "derived_column",
+      "alias": "diagnostic_interval",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "(SELECT CONCAT(TIMESTAMPDIFF(DAY, DATE(encounter_datetime), (SELECT date_patient_informed_referred FROM etl.flat_cervical_cancer_screening WHERE encounter_type = 147 AND person_id = p2.person_id ORDER BY encounter_datetime DESC LIMIT 1)), ' day(s)') FROM etl.flat_cervical_cancer_screening WHERE person_id = p2.person_id AND encounter_type = 69 and (select date_patient_informed_referred from etl.flat_cervical_cancer_screening where encounter_type = 147 and person_id = p2.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_cervical_cancer_screening where encounter_type = 69 and person_id = p2.person_id order by encounter_datetime desc limit 1) ORDER BY encounter_datetime DESC LIMIT 1)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "biopsy_results_within_2wks",
+      "expressionType": "case_statement",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "TIMESTAMPDIFF(day, DATE(fccs.encounter_datetime), DATE(prior_biopsy_result_date)) <= 14",
+            "value": 1
+          }
+        ]
+      }
+    }
+  ],
+  "filters": {
+    "conditionJoinOperator": "and",
+    "conditions": [
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fccs.age >= ?",
+        "parameterName": "startAge"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fccs.age <= ?",
+        "parameterName": "endAge"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "DATE(fccs.encounter_datetime) >= ?",
+        "parameterName": "startDate"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "DATE(fccs.encounter_datetime) <= ?",
+        "parameterName": "endDate"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fccs.encounter_type = 69"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fccs.location_uuid in ?",
+        "parameterName": "locationUuids"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "p5.gender in ?",
+        "parameterName": "genders"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "fccs.location_id not in (195)"
+      }
+    ]
+  },
+  "groupBy": {
+    "groupParam": "groupByParam",
+    "columns": [
+      "fccs.encounter_id"
+    ]
+  }
 }

--- a/oncology-reports/oncology-patient-list-cols.json
+++ b/oncology-reports/oncology-patient-list-cols.json
@@ -1,518 +1,1460 @@
- {
-     "142939b0-28a9-4649-baf9-a9d012bf3b3d" : {      
-        "program": "Breast Cancer",
-        "report": "Breast Cancer Screening",
-        "indicators": [{
-                "indicator": "total_breast_screened",
-                "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age" , "phone_number" ,"type_of_abnormality" , "patient_uuid", "screening_mode", "diagnostic_interval","date_patient_informed_of_results"
-                ]
-
-            },
-            {
-                "indicator": "normal_breast_screening_findings",
-                "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "hiv_status" ,"patient_uuid", "screening_mode", "diagnostic_interval","date_patient_informed_of_results"
-                ]
-
-            },
-            {
-                "indicator": "normal_breast_screening_findings_below_30yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid","date_patient_informed_of_results"
-                ]
-
-            },
-            {
-                "indicator": "normal_breast_screening_findings_30_to_40yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid","date_patient_informed_of_results"
-                ]
-
-            },
-            {
-                "indicator": "normal_breast_screening_findings_41_to_50yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid","date_patient_informed_of_results"
-                ]
-
-            },
-            {
-                "indicator": "normal_breast_screening_findings_51_to_69yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid","date_patient_informed_of_results"
-                ]
-
-            },
-            {
-                "indicator": "normal_breast_screening_findings_above_70yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid","date_patient_informed_of_results"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_breast_screening_findings",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_breast_screening_findings_below_30yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_breast_screening_findings_30_to_40yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_breast_screening_findings_41_to_50yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_breast_screening_findings_51_to_69yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_breast_screening_findings_above_70yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_breast_call_rate",
-                "patientListCols": [
-                ]
-
-            },
-            {
-                "indicator": "normal_breast_call_rate",
-                "patientListCols": [
-                ]
-
-            },
-            {
-                "indicator": "diagnostic_interval",
-                "patientListCols": [ "encounter_datetime" , "location_name", "identifiers" , "person_name" , "gender" , "age" , "phone_number", "diagnosis" ,
-                     "date_patient_informed_of_results" , "diagnostic_interval" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "clients_staged_before_treatment",
-                "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "total_reffered_for_followup",
-                "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" ,"phone_number" ,"patient_uuid"
-                ]
-            },
-            {
-                "indicator": "biopsy_results_within_2wks",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "biopsy_results_within_2wks",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-                ]
-
-            }
+{
+  "142939b0-28a9-4649-baf9-a9d012bf3b3d": {
+    "program": "Breast Cancer",
+    "report": "Breast Cancer Screening",
+    "indicators": [
+      {
+        "indicator": "total_breast_screened",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "screening_mode",
+          "diagnostic_interval",
+          "date_patient_informed_of_results"
         ]
-    },
-    "cad71628-692c-4d8f-8dac-b2e20bece27f": {
-        "program": "Cervical Cancer",
-        "report": "Cervical Cancer Screening",
-        "indicators": [
-            {
-                "indicator": "total_cervical_screened",
-                "patientListCols": ["encounter_datetime" , "location_name" ,"identifiers", "person_name" , "gender" , "age" , "type_of_abnormality" ,"procedure_done" ,"patient_uuid","date_patient_informed_of_results"
-                ]
-            },
-            {
-                "indicator": "normal_cervical_screening",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers", "person_name" , "gender" , "age" ,"hiv_status",  "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "normal_cervical_screening_below_30yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "normal_cervical_screening_30_to_40yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "normal_cervical_screening_41_to_50yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "normal_cervical_screening_51_to_69yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "normal_cervical_screening_above_70yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_cervical_screening",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers", "person_name" , "gender", "age" , "hiv_status" , "phone_number" , "type_of_abnormality" ,
-                     "procedure_done" , "patient_uuid", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_cervical_screening_below_30yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" , "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_cervical_screening_30_to_40yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" ,"procedure_done", "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_cervical_screening_41_to_50yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" ,"procedure_done", "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_cervical_screening_51_to_69yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" ,"procedure_done", "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_cervical_screening_above_70yrs",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "hiv_status" , "phone_number" ,"type_of_abnormality" ,"procedure_done", "patient_uuid", "screening_mode", "diagnostic_interval"
-                ]
-
-            },
-            {
-                "indicator": "abnormal_cervical_call_rate",
-                "patientListCols": [
-                ]
-
-            },
-            {
-                "indicator": "normal_cervical_call_rate",
-                "patientListCols": [
-                ]
-
-            },
-            {
-                "indicator": "diagnostic_interval",
-                "patientListCols": [ "encounter_datetime" , "location_name","identifiers","person_name","gender","age", "phone_number", "diagnosis" , "cancer_stage",
-                    "date_patient_informed_of_results" , "diagnostic_interval" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "clients_staged_before_treatment",
-                "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "total_reffered_for_followup",
-                "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" ,  "phone_number" , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "biopsy_results_within_2wks",
-                "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-                ]
-
-            }
+      },
+      {
+        "indicator": "normal_findings",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "hiv_status",
+          "patient_uuid",
+          "screening_mode",
+          "diagnostic_interval",
+          "date_patient_informed_of_results"
         ]
-    },
-    "b2837614-e144-4bec-abc2-e9f5e3116bb9" : {      
-        "program": "Breast and Cervical Cancer Screening",
-        "report": "Breast and Cervical Cancer Screening",
-        "indicators": [{
-                "indicator": "total_breast_screened",
-                "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age" , "phone_number"  , "patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "total_cervical_screened",
-                "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender"  ,"patient_uuid"
-                ]
-
-            },
-            {
-                "indicator": "total_breast_and_cervical_screened",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age" , "phone_number"  , "patient_uuid"
-                ]
-
-            }
+      },
+      {
+        "indicator": "normal_below_30yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "date_patient_informed_of_results"
         ]
-    },
-    "1a5a9a8d-f4a8-4c48-b63a-22f84530b4b9" : {      
-        "program": "Lung Cancer Treatment",
-        "report": "Lung Cancer Treatment",
-        "indicators": [{
-            "indicator": "enrolled_patients",
-            "patientListCols": ["encounter_datetime", "location_name", "identifiers", "person_name", "gender", "age", "phone_number", "hiv_status"]
-
-            },
-            {
-                "indicator": "deceased",
-                "patientListCols": ["encounter_datetime", "location_name", "identifiers", "person_name", "gender", "age", "phone_number"]
-
-            },
-            {
-                "indicator": "lost_to_follow_up",
-                "patientListCols": ["encounter_datetime", "location_name", "identifiers", "person_name", "gender", "age", "phone_number"]
-
-            },
-            {
-                "indicator": "active_patients",
-                "patientListCols": ["encounter_datetime", "location_name", "identifiers", "person_name", "gender", "age", "phone_number"]
-
-            },
-            {
-                "indicator": "for_staging",
-                "patientListCols": ["encounter_datetime", "location_name", "identifiers", "person_name", "gender", "age", "phone_number"]
-
-            },
-            {
-                "indicator": "referred_from_clinic",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number", "referred_from"
-                ]
-
-            },
-            {
-                "indicator": "non_small_cell_lung_cancer",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number"
-                ]
-            },
-            {
-                "indicator": "epidermoid_carcinoma",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number"
-                ]
-            },
-            {
-                "indicator": "adenocarcinoma",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number"
-                ]
-            },
-            {
-                "indicator": "large cell carcinoma",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number"
-                ]
-            },
-            {
-                "indicator": "mixed squamous",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number"
-                ]
-            },
-            {
-                "indicator": "small cell lung cancer",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number"
-                ]
-            },
-            {
-                "indicator": "stage_one",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number ", "metastasis_region"
-                ]
-            },
-            {
-                "indicator": "stage_two",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number", "metastasis_region"
-                ]
-            },
-            {
-                "indicator": "stage_three",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number", "metastasis_region"
-                ]
-            },
-            {
-                "indicator": "stage_four",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number", "metastasis_region"
-                ]
-            },
-            {
-                "indicator": "limited stage",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number", "metastasis_region"
-                ]
-            },
-            {
-                "indicator": "extensive stage",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number", "metastasis_region"
-                ]
-            },
-            {
-                "indicator": "chemotherapy",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number"
-                ]
-            },
-            {
-                "indicator": "radiotherapy",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number"
-                ]
-            },
-            {
-                "indicator": "surgery",
-                "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age", "phone_number"
-                ]
-            }
+      },
+      {
+        "indicator": "normal_30_to_40yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "date_patient_informed_of_results"
         ]
-    },
-    "b2db2bdf-67e9-42c5-858c-c7e435742ef5" : {  
+      },
+      {
+        "indicator": "normal_41_to_50yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "date_patient_informed_of_results"
+        ]
+      },
+      {
+        "indicator": "normal_51_to_69yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "date_patient_informed_of_results"
+        ]
+      },
+      {
+        "indicator": "normal_above_70yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "date_patient_informed_of_results"
+        ]
+      },
+      {
+        "indicator": "abnormal_findings",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "screening_mode",
+          "diagnostic_interval",
+          "breast_complaints_three_months",
+          "breast_mass_location",
+          "nipple_discharge_location",
+          "nipple_retraction_location",
+          "breast_erythrema_location",
+          "breast_rash_location",
+          "breast_pain_location",
+          "other_changes_location",
+          "history_of_mammogram",
+          "mammogram_results",
+          "breast_ultrasound_history",
+          "breast_ultrasound_result",
+          "history_of_breast_biopsy",
+          "breast_biopsy_results",
+          "number_of_biopsies",
+          "biopsy_type"
+        ]
+      },
+      {
+        "indicator": "abnormal_below_30yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "screening_mode",
+          "diagnostic_interval",
+          "breast_complaints_three_months",
+          "breast_mass_location",
+          "nipple_discharge_location",
+          "nipple_retraction_location",
+          "breast_erythrema_location",
+          "breast_rash_location",
+          "breast_pain_location",
+          "other_changes_location",
+          "history_of_mammogram",
+          "mammogram_results",
+          "breast_ultrasound_history",
+          "breast_ultrasound_result",
+          "history_of_breast_biopsy",
+          "breast_biopsy_results",
+          "number_of_biopsies",
+          "biopsy_type"
+        ]
+      },
+      {
+        "indicator": "abnormal_30_to_40yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "screening_mode",
+          "diagnostic_interval",
+          "breast_complaints_three_months",
+          "breast_mass_location",
+          "nipple_discharge_location",
+          "nipple_retraction_location",
+          "breast_erythrema_location",
+          "breast_rash_location",
+          "breast_pain_location",
+          "other_changes_location",
+          "history_of_mammogram",
+          "mammogram_results",
+          "breast_ultrasound_history",
+          "breast_ultrasound_result",
+          "history_of_breast_biopsy",
+          "breast_biopsy_results",
+          "number_of_biopsies",
+          "biopsy_type"
+        ]
+      },
+      {
+        "indicator": "abnormal_41_to_50yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "screening_mode",
+          "diagnostic_interval",
+          "breast_complaints_three_months",
+          "breast_mass_location",
+          "nipple_discharge_location",
+          "nipple_retraction_location",
+          "breast_erythrema_location",
+          "breast_rash_location",
+          "breast_pain_location",
+          "other_changes_location",
+          "history_of_mammogram",
+          "mammogram_results",
+          "breast_ultrasound_history",
+          "breast_ultrasound_result",
+          "history_of_breast_biopsy",
+          "breast_biopsy_results",
+          "number_of_biopsies",
+          "biopsy_type"
+        ]
+      },
+      {
+        "indicator": "abnormal_51_to_69yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "screening_mode",
+          "diagnostic_interval",
+          "breast_complaints_three_months",
+          "breast_mass_location",
+          "nipple_discharge_location",
+          "nipple_retraction_location",
+          "breast_erythrema_location",
+          "breast_rash_location",
+          "breast_pain_location",
+          "other_changes_location",
+          "history_of_mammogram",
+          "mammogram_results",
+          "breast_ultrasound_history",
+          "breast_ultrasound_result",
+          "history_of_breast_biopsy",
+          "breast_biopsy_results",
+          "number_of_biopsies",
+          "biopsy_type"
+        ]
+      },
+      {
+        "indicator": "abnormal_above_70yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid",
+          "screening_mode",
+          "diagnostic_interval",
+          "breast_complaints_three_months",
+          "breast_mass_location",
+          "nipple_discharge_location",
+          "nipple_retraction_location",
+          "breast_erythrema_location",
+          "breast_rash_location",
+          "breast_pain_location",
+          "other_changes_location",
+          "history_of_mammogram",
+          "mammogram_results",
+          "breast_ultrasound_history",
+          "breast_ultrasound_result",
+          "history_of_breast_biopsy",
+          "breast_biopsy_results",
+          "number_of_biopsies",
+          "biopsy_type"
+        ]
+      },
+      {
+        "indicator": "abnormal_breast_call_rate",
+        "patientListCols": []
+      },
+      {
+        "indicator": "normal_breast_call_rate",
+        "patientListCols": []
+      },
+      {
+        "indicator": "diagnostic_interval",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "diagnosis",
+          "date_patient_informed_of_results",
+          "diagnostic_interval",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "clients_staged_before_treatment",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "total_reffered_for_followup",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "biopsy_results_within_2wks",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "biopsy_results_within_2wks",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "male_patients",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "female_patients",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_negative",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_status_unknown",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_positive",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      }
+    ]
+  },
+  "cad71628-692c-4d8f-8dac-b2e20bece27f": {
+    "program": "Cervical Cancer",
+    "report": "Cervical Cancer Screening",
+    "indicators": [
+      {
+        "indicator": "total_cervical_screened",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "type_of_abnormality",
+          "procedure_done",
+          "patient_uuid",
+          "date_patient_informed_of_results"
+        ]
+      },
+      {
+        "indicator": "normal_findings",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "normal_below_30yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "normal_30_to_40yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "normal_41_to_50yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "normal_51_to_69yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "normal_above_70yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "type_of_abnormality",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "abnormal_findings",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "diagnostic_interval",
+          "type_of_abnormality",
+          "via_procedure_done",
+          "other_via_procedure_done",
+          "patient_uuid",
+          "prior_via_done",
+          "prior_via_date",
+          "prior_via_result",
+          "visual_impression_cervix",
+          "visual_impression_vagina",
+          "visual_impression_vulva",
+          "via_management_plan",
+          "via_rtc_date"
+        ]
+      },
+      {
+        "indicator": "abnormal_below_30yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "diagnostic_interval",
+          "type_of_abnormality",
+          "via_procedure_done",
+          "other_via_procedure_done",
+          "patient_uuid",
+          "prior_via_done",
+          "prior_via_date",
+          "prior_via_result",
+          "visual_impression_cervix",
+          "visual_impression_vagina",
+          "visual_impression_vulva",
+          "via_management_plan",
+          "via_rtc_date"
+        ]
+      },
+      {
+        "indicator": "abnormal_30_to_40yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "diagnostic_interval",
+          "type_of_abnormality",
+          "via_procedure_done",
+          "other_via_procedure_done",
+          "patient_uuid",
+          "prior_via_done",
+          "prior_via_date",
+          "prior_via_result",
+          "visual_impression_cervix",
+          "visual_impression_vagina",
+          "visual_impression_vulva",
+          "via_management_plan",
+          "via_rtc_date"
+        ]
+      },
+      {
+        "indicator": "abnormal_41_to_50yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "diagnostic_interval",
+          "type_of_abnormality",
+          "via_procedure_done",
+          "other_via_procedure_done",
+          "patient_uuid",
+          "prior_via_done",
+          "prior_via_date",
+          "prior_via_result",
+          "visual_impression_cervix",
+          "visual_impression_vagina",
+          "visual_impression_vulva",
+          "via_management_plan",
+          "via_rtc_date"
+        ]
+      },
+      {
+        "indicator": "abnormal_51_to_69yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "diagnostic_interval",
+          "type_of_abnormality",
+          "via_procedure_done",
+          "other_via_procedure_done",
+          "patient_uuid",
+          "prior_via_done",
+          "prior_via_date",
+          "prior_via_result",
+          "visual_impression_cervix",
+          "visual_impression_vagina",
+          "visual_impression_vulva",
+          "via_management_plan",
+          "via_rtc_date"
+        ]
+      },
+      {
+        "indicator": "abnormal_above_70yrs",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "hiv_status",
+          "phone_number",
+          "diagnostic_interval",
+          "type_of_abnormality",
+          "via_procedure_done",
+          "other_via_procedure_done",
+          "patient_uuid",
+          "prior_via_done",
+          "prior_via_date",
+          "prior_via_result",
+          "visual_impression_cervix",
+          "visual_impression_vagina",
+          "visual_impression_vulva",
+          "via_management_plan",
+          "via_rtc_date"
+        ]
+      },
+      {
+        "indicator": "abnormal_cervical_call_rate",
+        "patientListCols": []
+      },
+      {
+        "indicator": "normal_cervical_call_rate",
+        "patientListCols": []
+      },
+      {
+        "indicator": "diagnostic_interval",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "diagnosis",
+          "cancer_stage",
+          "date_patient_informed_of_results",
+          "diagnostic_interval",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "clients_staged_before_treatment",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "total_reffered_for_followup",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "biopsy_results_within_2wks",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_negative",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_status_unknown",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_positive",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      }
+    ]
+  },
+  "b2837614-e144-4bec-abc2-e9f5e3116bb9": {
+    "program": "Breast and Cervical Cancer Screening",
+    "report": "Breast and Cervical Cancer Screening",
+    "indicators": [
+      {
+        "indicator": "total_breast_screened",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "total_cervical_screened",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "total_breast_and_cervical_screened",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      }
+    ]
+  },
+  "1a5a9a8d-f4a8-4c48-b63a-22f84530b4b9": {
+    "program": "Lung Cancer Treatment",
+    "report": "Lung Cancer Treatment",
+    "indicators": [
+      {
+        "indicator": "enrolled_patients",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "deceased",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "lost_to_follow_up",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "active_patients",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "for_staging",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "referred_from_clinic",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "referred_from"
+        ]
+      },
+      {
+        "indicator": "non_small_cell_lung_cancer",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "epidermoid_carcinoma",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "adenocarcinoma",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "large cell carcinoma",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "mixed squamous",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "small cell lung cancer",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "stage_one",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number ",
+          "metastasis_region"
+        ]
+      },
+      {
+        "indicator": "stage_two",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "metastasis_region"
+        ]
+      },
+      {
+        "indicator": "stage_three",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "metastasis_region"
+        ]
+      },
+      {
+        "indicator": "stage_four",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "metastasis_region"
+        ]
+      },
+      {
+        "indicator": "limited stage",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "metastasis_region"
+        ]
+      },
+      {
+        "indicator": "extensive stage",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "metastasis_region"
+        ]
+      },
+      {
+        "indicator": "chemotherapy",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "radiotherapy",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      },
+      {
+        "indicator": "surgery",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number"
+        ]
+      }
+    ]
+  },
+  "b2db2bdf-67e9-42c5-858c-c7e435742ef5": {
     "program": "Lung Cancer",
     "report": "Lung Cancer Screening",
-    "indicators": [{
-            "indicator": "total_lung_screened",
-            "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" ,  "age" , "phone_number" , "patient_uuid"
-            ]
-
-        },
-        {
-            "indicator": "walk_in",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-            ]
-
-        },
-        {
-            "indicator": "referred_from_clinic",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid", "referred_from"
-            ]
-
-        },
-        {
-            "indicator": "cigarette_smoking",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid", "pack_years"
-            ]
-
-        },
-        {
-            "indicator": "tobacco_use",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-            ]
-
-        },
-        {
-            "indicator": "chemical_exposure",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-            ]
-
-        },
-        {
-            "indicator": "asbestos_exposure",
-            "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-            ]
-
-        },
-        {
-            "indicator": "hiv_positive",
-            "patientListCols": [ "encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" ,"phone_number" ,"patient_uuid"
-            ]
-        },
-        {
-            "indicator": "hiv_negative",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-            ]
-
-        },
-        {
-            "indicator": "hiv_status_unknown",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-            ]
-
-        },
-        {
-            "indicator": "tb_treatment_received",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-            ]
-
-        },
-        {
-            "indicator": "no_tb_treatment",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid"
-            ]
-
-        },
-        {
-            "indicator": "normal_xray_results",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid", "imaging_results_description"
-            ]
-
-        },
-        {
-            "indicator": "abnormal_xray_results",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid", "imaging_results_description"
-            ]
-
-        },
-        {
-            "indicator": "indication_of_lung_mass_from_ct_findings",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid", "imaging_results_description"
-            ]
-
-        },
-        {
-            "indicator": "indication_of_mediastial_mass_from_ct_findings",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid", "imaging_results_description"
-            ]
-
-        },
-        {
-            "indicator": "indication_of_pleural_mass_from_ct_findings",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "phone_number" , "patient_uuid", "imaging_results_description"
-            ]
-
-        },
-        {
-            "indicator": "non_respiratory_disease",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "patient_uuid", "biopsy_result", "biopsy_workup_date", "diagnosis_date", "imaging_results_description", "diagnosis_interval", "referrals"
-            ]
-
-        },
-        {
-            "indicator": "biopsy_done",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "patient_uuid", "biopsy_result", "biopsy_workup_date", "diagnosis_date", "imaging_results_description", "diagnosis_interval", "referrals"
-            ]
-
-        },
-        {
-            "indicator": "biopsy_not_done",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "patient_uuid", "biopsy_result", "biopsy_workup_date", "diagnosis_date", "imaging_results_description", "diagnosis_interval", "referrals"
-            ]
-
-        },
-        {
-            "indicator": "non_small_cell_lung_cancer",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "patient_uuid", "biopsy_result", "biopsy_workup_date", "diagnosis_date", "imaging_results_description", "diagnosis_interval", "referrals"
-            ]
-
-        },
-        {
-            "indicator": "small_cell_lung_cancer",
-            "patientListCols": ["encounter_datetime" , "location_name" , "identifiers" , "person_name" , "gender" , "age" , "patient_uuid", "biopsy_result", "biopsy_workup_date", "diagnosis_date", "imaging_results_description", "diagnosis_interval", "referrals"
-            ]
-
-        }
-    ]  
-}  
+    "indicators": [
+      {
+        "indicator": "total_lung_screened",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "walk_in",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "referred_from_clinic",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "referred_from"
+        ]
+      },
+      {
+        "indicator": "cigarette_smoking",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "pack_years"
+        ]
+      },
+      {
+        "indicator": "tobacco_use",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "chemical_exposure",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "asbestos_exposure",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_positive",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_negative",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_status_unknown",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "tb_treatment_received",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "no_tb_treatment",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "normal_xray_results",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "imaging_results_description"
+        ]
+      },
+      {
+        "indicator": "abnormal_xray_results",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "imaging_results_description"
+        ]
+      },
+      {
+        "indicator": "indication_of_lung_mass_from_ct_findings",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "imaging_results_description"
+        ]
+      },
+      {
+        "indicator": "indication_of_mediastial_mass_from_ct_findings",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "imaging_results_description"
+        ]
+      },
+      {
+        "indicator": "indication_of_pleural_mass_from_ct_findings",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "imaging_results_description"
+        ]
+      },
+      {
+        "indicator": "non_respiratory_disease",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "patient_uuid",
+          "biopsy_result",
+          "biopsy_workup_date",
+          "diagnosis_date",
+          "imaging_results_description",
+          "diagnosis_interval",
+          "referrals"
+        ]
+      },
+      {
+        "indicator": "biopsy_done",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "patient_uuid",
+          "biopsy_result",
+          "biopsy_workup_date",
+          "diagnosis_date",
+          "imaging_results_description",
+          "diagnosis_interval",
+          "referrals"
+        ]
+      },
+      {
+        "indicator": "biopsy_not_done",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "patient_uuid",
+          "biopsy_result",
+          "biopsy_workup_date",
+          "diagnosis_date",
+          "imaging_results_description",
+          "diagnosis_interval",
+          "referrals"
+        ]
+      },
+      {
+        "indicator": "non_small_cell_lung_cancer",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "patient_uuid",
+          "biopsy_result",
+          "biopsy_workup_date",
+          "diagnosis_date",
+          "imaging_results_description",
+          "diagnosis_interval",
+          "referrals"
+        ]
+      },
+      {
+        "indicator": "small_cell_lung_cancer",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "patient_uuid",
+          "biopsy_result",
+          "biopsy_workup_date",
+          "diagnosis_date",
+          "imaging_results_description",
+          "diagnosis_interval",
+          "referrals"
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
This PR adds new columns to the breast screening and cervical screening reports. The following columns are added to the breast screening and cervical screening aggregate report:

- male_patients (count) (breast only)
- female_patients (count) (breast only)
- hiv_negative (count)
- hiv_status_unknown (count)
- hiv_positive (count)

The columns in the aggregate are also reordered so that normal and abnormal findings are arranged consecutively for easier side-by-side comparison. The Location and Period columns are pinned so that they always stay visible when scrolling across the report. 

It also modifies the patient list for breast screening patients with abnormal findings to include the following columns:

- breast_mass_location
- nipple_discharge_location
- nipple_retraction_location
- breast_erythrema_location
- breast_rash_location
- breast_pain_location
- other_changes_location
- history_of_mammogram
- mammogram_results
- breast_ultrasound_history
- breast_ultrasound_result
- history_of_breast_biopsy
- breast_biopsy_results
- number_of_biopsies
- biopsy_type

As well as the patient list for cervical screening patients with abnormal findings to include the following columns:

- prior_via_done
- prior_via_date
- prior_via_result
- visual_impression_cervix
- visual_impression_vagina
- visual_impression_vulva
- via_procedure_done
- via_management_plan
- via_rtc_date