### PR TITLE
POCONC-173: Add HIV status disaggregation by age to oncology reports

### DIFF
--- a/app/reporting-framework/json-reports/breast-cancer-daily-screening-summary-aggregate.json
+++ b/app/reporting-framework/json-reports/breast-cancer-daily-screening-summary-aggregate.json
@@ -44,6 +44,22 @@
     },
     {
       "type": "derived_column",
+      "alias": "gender",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(person_id)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(person_id)"
+      }
+    },
+    {
+      "type": "derived_column",
       "alias": "normal_findings",
       "expressionType": "simple_expression",
       "expressionOptions": {
@@ -112,6 +128,78 @@
       "expressionType": "simple_expression",
       "expressionOptions": {
         "expression": "count(hiv_positive)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_over_50)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_over_50)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_over_50)"
       }
     },
     {

--- a/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-aggregate.json
+++ b/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-aggregate.json
@@ -3,218 +3,307 @@
   "version": "1.0",
   "tag": "breast_cancer_summary_aggregate",
   "uses": [
-      {
-          "name": "breastCancerMonthlySummaryBase",
-          "version": "1.0",
-          "type": "dataset_def"
-      }
+    {
+      "name": "breastCancerMonthlySummaryBase",
+      "version": "1.0",
+      "type": "dataset_def"
+    }
   ],
   "sources": [
-      {
-          "dataSet": "breastCancerMonthlySummaryBase",
-          "alias": "bcsd"
-      }
+    {
+      "dataSet": "breastCancerMonthlySummaryBase",
+      "alias": "bcsd"
+    }
   ],
-  "columns": [{
-    "type": "simple_column",
-    "alias": "location_name",
-    "column": "location_name"
-  },
-  {
-    "type": "simple_column",
-    "alias": "location_uuid",
-    "column": "location_uuid"
-  },
-  {
-    "type": "derived_column",
-    "alias": "encounter_datetime",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "date_format(bcsd.encounter_datetime, '%m-%Y')"
+  "columns": [
+    {
+      "type": "simple_column",
+      "alias": "location_name",
+      "column": "location_name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_uuid",
+      "column": "location_uuid"
+    },
+    {
+      "type": "derived_column",
+      "alias": "encounter_datetime",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "date_format(bcsd.encounter_datetime, '%m-%Y')"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "total_breast_screened",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(person_id)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "gender",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(person_id)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(person_id)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_findings)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_findings",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_findings)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_breast_call_rate%",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": " ROUND(count(normal_findings)/count(person_id)*100,2)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_breast_call_rate%",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "ROUND(count(abnormal_findings)/count(person_id)*100,2)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "male_patients",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(male_patients)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "female_patients",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(female_patients)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status_unknown",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_status_unknown)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_over_50)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_over_50)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_over_50)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_below_30yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_below_30yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_below_30yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_30_to_40yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_30_to_40yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_30_to_40yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_41_to_50yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_41_to_50yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_41_to_50yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_51_to_69yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_51_to_69yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_51_to_69yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "normal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(normal_above_70yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "abnormal_above_70yrs",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(abnormal_above_70yrs)"
+      }
     }
-  },
-  {
-    "type": "derived_column",
-    "alias": "total_breast_screened",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(person_id)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "normal_findings",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(normal_findings)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "abnormal_findings",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(abnormal_findings)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "normal_breast_call_rate%",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": " ROUND(count(normal_findings)/count(person_id)*100,2)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "abnormal_breast_call_rate%",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "ROUND(count(abnormal_findings)/count(person_id)*100,2)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "male_patients",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(male_patients)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "female_patients",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(female_patients)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "hiv_negative",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(hiv_negative)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "hiv_status_unknown",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(hiv_status_unknown)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "hiv_positive",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(hiv_positive)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "normal_below_30yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(normal_below_30yrs)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "abnormal_below_30yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(abnormal_below_30yrs)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "normal_30_to_40yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(normal_30_to_40yrs)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "abnormal_30_to_40yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(abnormal_30_to_40yrs)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "normal_41_to_50yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(normal_41_to_50yrs)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "abnormal_41_to_50yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(abnormal_41_to_50yrs)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "normal_51_to_69yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(normal_51_to_69yrs)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "abnormal_51_to_69yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(abnormal_51_to_69yrs)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "normal_above_70yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(normal_above_70yrs)"
-    }
-  },
-  {
-    "type": "derived_column",
-    "alias": "abnormal_above_70yrs",
-    "expressionType": "simple_expression",
-    "expressionOptions": {
-      "expression": "count(abnormal_above_70yrs)"
-    }
-  }
-],
+  ],
   "groupBy": {
-      "groupParam": "groupByParam",
-      "columns": [
-          "location_id",
-          "year(bcsd.encounter_datetime)",
-          "month(bcsd.encounter_datetime)"
-      ],
-      "excludeParam": "excludeParam"
+    "groupParam": "groupByParam",
+    "columns": [
+      "location_id",
+      "year(bcsd.encounter_datetime)",
+      "month(bcsd.encounter_datetime)"
+    ],
+    "excludeParam": "excludeParam"
   },
   "dynamicJsonQueryGenerationDirectives": {
-      "patientListGenerator": {
-          "useTemplate": "breast_cancer_patient_list_template",
-          "useTemplateVersion": "1.0",
-          "generatingDirectives": {
-              "joinDirectives": {
-                  "joinType": "INNER",
-                  "joinCondition": "<<base_column>> = <<template_column>>",
-                  "baseColumn": "person_id",
-                  "templateColumn": "person_id"
-              }
-          }
+    "patientListGenerator": {
+      "useTemplate": "breast_cancer_patient_list_template",
+      "useTemplateVersion": "1.0",
+      "generatingDirectives": {
+        "joinDirectives": {
+          "joinType": "INNER",
+          "joinCondition": "<<base_column>> = <<template_column>>",
+          "baseColumn": "person_id",
+          "templateColumn": "person_id"
+        }
       }
+    }
   }
 }

--- a/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-base.json
+++ b/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-base.json
@@ -78,6 +78,11 @@
     },
     {
       "type": "simple_column",
+      "alias": "gender",
+      "column": "fbcs.gender"
+    },
+    {
+      "type": "simple_column",
       "alias": "age",
       "column": "fbcs.age"
     },
@@ -89,9 +94,94 @@
     {
       "type": "derived_column",
       "alias": "type_of_abnormality",
-      "expressionType": "simple_expression",
+      "expressionType": "case_statement",
       "expressionOptions": {
-        "expression": "case when cur_physical_findings=0 then 'Normal' when cur_physical_findings=1 then 'Mastitis' when cur_physical_findings=2 then 'Breast lumps' when cur_physical_findings=3 then 'Cracked nipple' when cur_physical_findings=4 then 'Others' when cur_physical_findings=5 then 'Mass' when cur_physical_findings=6 then 'Nipple discharge' when cur_physical_findings=7 then 'Breast skin changes' when cur_physical_findings=8 then 'Not done' when cur_physical_findings=9 then 'Abscess breast' when cur_physical_findings=10 then 'Breast engorgement' when cur_physical_findings=11 then 'Abnormal' when cur_physical_findings=12 then 'Calor' when cur_physical_findings=13 then 'Peau Dorange' when cur_physical_findings=14 then 'Unknown' when cur_physical_findings=15 then 'Fine nodularity' when cur_physical_findings=16 then 'Dense nodularity' when cur_physical_findings=17 then 'Skin edema' when cur_physical_findings=18 then 'Nipple areolar change' when cur_physical_findings=19 then 'Muscle tenderness' when cur_physical_findings=20 then 'Benign' else null end"
+        "caseOptions": [
+          {
+            "condition": "cur_physical_findings = 0",
+            "value": "Normal"
+          },
+          {
+            "condition": "cur_physical_findings = 1",
+            "value": "Mastitis"
+          },
+          {
+            "condition": "cur_physical_findings = 2",
+            "value": "Breast lumps"
+          },
+          {
+            "condition": "cur_physical_findings = 3",
+            "value": "Cracked nipple"
+          },
+          {
+            "condition": "cur_physical_findings = 4",
+            "value": "Other"
+          },
+          {
+            "condition": "cur_physical_findings = 5",
+            "value": "Mass"
+          },
+          {
+            "condition": "cur_physical_findings = 6",
+            "value": "Nipple discharge"
+          },
+          {
+            "condition": "cur_physical_findings = 7",
+            "value": "Breast skin changes"
+          },
+          {
+            "condition": "cur_physical_findings = 8",
+            "value": "Not done"
+          },
+          {
+            "condition": "cur_physical_findings = 9",
+            "value": "Breast abscess"
+          },
+          {
+            "condition": "cur_physical_findings = 10",
+            "value": "Breast engorgement"
+          },
+          {
+            "condition": "cur_physical_findings = 11",
+            "value": "Abnormal"
+          },
+          {
+            "condition": "cur_physical_findings = 12",
+            "value": "Calor"
+          },
+          {
+            "condition": "cur_physical_findings = 13",
+            "value": "Peau dOrange"
+          },
+          {
+            "condition": "cur_physical_findings = 14",
+            "value": "Unknown"
+          },
+          {
+            "condition": "cur_physical_findings = 15",
+            "value": "Fine nodularity"
+          },
+          {
+            "condition": "cur_physical_findings = 16",
+            "value": "Dense nodularity"
+          },
+          {
+            "condition": "cur_physical_findings = 17",
+            "value": "Skin edema"
+          },
+          {
+            "condition": "cur_physical_findings = 18",
+            "value": "Nipple areolar change"
+          },
+          {
+            "condition": "cur_physical_findings = 19",
+            "value": "Muscle tenderness"
+          },
+          {
+            "condition": "cur_physical_findings = 20",
+            "value": "Benign"
+          }
+        ]
       }
     },
     {
@@ -711,6 +801,78 @@
     },
     {
       "type": "derived_column",
+      "alias": "hiv_positive_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 2 and age < 25, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 1 and age < 25, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 3 and age < 30, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 2 and age >= 25 and age < 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 1 and age >= 25 and age < 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 3 and age >= 25 and age < 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 3 and age > 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 1 and age > 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fbcs.hiv_status = 3 and age > 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
       "alias": "clients_staged_before_treatment",
       "expressionType": "simple_expression",
       "expressionOptions": {
@@ -786,6 +948,19 @@
             "value": "Stage IV"
           }
         ]
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "date_patient_informed_of_results",
+      "column": "(select DATE_FORMAT(date_patient_informed_and_referred_for_management, '%d-%M-%Y') from etl.flat_breast_cancer_screening where encounter_type = 145 and (select date_patient_informed_and_referred_for_management from etl.flat_breast_cancer_screening where encounter_type = 145 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_breast_cancer_screening where encounter_type = 86 and person_id = p.person_id order by encounter_datetime desc limit 1) and person_id = p.person_id order by encounter_datetime desc limit 1)"
+    },
+    {
+      "type": "derived_column",
+      "alias": "total_reffered_for_followup",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(referrals_ordered = 1, 1, NULL)"
       }
     }
   ],

--- a/app/reporting-framework/json-reports/breast-cancer-patient-list-template.json
+++ b/app/reporting-framework/json-reports/breast-cancer-patient-list-template.json
@@ -1,194 +1,193 @@
 {
-    "name": "breast_cancer_patient_list_template",
-    "version": "1.0",
-    "tag": "breast_cancer_patient_list_template",
-    "description": "Breast Cancer patient list template",
-    "sources": [
-        {
-            "table": "amrs.person",
-            "alias": "t1"
-        },
-        {
-            "table": "amrs.person_name",
-            "alias": "person_name",
-            "join": {
-                "type": "INNER",
-                "joinCondition": "t1.person_id = person_name.person_id AND (person_name.voided IS NULL || person_name.voided = 0)"
-            }
-        },
-        {
-            "table": "amrs.patient_identifier",
-            "alias": "id",
-            "join": {
-                "type": "LEFT",
-                "joinCondition": "t1.person_id = id.patient_id AND (id.voided IS NULL || id.voided = 0)"
-            }
-        }
-    ],
-    "columns": [
-        {
-            "type": "simple_column",
-            "alias": "patient_uuid",
-            "column": "t1.uuid"
-        },
-        {
-            "type": "simple_column",
-            "alias": "person_id",
-            "column": "t1.person_id"
-        },
-        {
-            "type": "simple_column",
-            "alias": "gender",
-            "column": "t1.gender"
-        },
-        {
-            "type": "simple_column",
-            "alias": "birthdate",
-            "column": "t1.birthdate"
-        },
-        {
-            "type": "derived_column",
-            "alias": "age",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "extract(year from (from_days(datediff(now(),t1.birthdate))))"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "hiv_status",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "case when hiv_status=1 then 'HIV Negative' when hiv_status=2 then 'HIV Positive' when hiv_status=3 then 'Unknown' else NULL end"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "person_name",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": " CONCAT(COALESCE(person_name.given_name, ''), ' ', COALESCE(person_name.middle_name, ''), ' ', COALESCE(person_name.family_name, ''))"
-            }
-        },
-        {
-            "type": "simple_column",
-            "alias": "given_name",
-            "column": "person_name.given_name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "family_name",
-            "column": "person_name.family_name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "middle_name",
-            "column": "person_name.middle_name"
-        },
-        {
-            "type": "derived_column",
-            "alias": "identifiers",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": " GROUP_CONCAT(DISTINCT id.identifier SEPARATOR ', ')"
-            }
-        },
-       
-        {
-            "type": "simple_column",
-            "alias": "date_patient_informed_of_results",
-            "column": "date_patient_informed_and_referred_for_management"
-        },
-        {
-            "type": "derived_column",
-            "alias": "diagnostic_interval",
-            "expressionType": "simple_expression",
-            "expressionOptions": {
-                "expression": "timestampdiff(day,date(encounter_datetime),date(date_patient_informed_and_referred_for_management))"
-            }
-        },
-        {
-            "type": "derived_column",
-            "alias": "procedure_done",
-            "expressionType": "case_statement",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "procedure_done = 1",
-                        "value": "Ultrasound"
-                    },
-                    
-                    {
-                        "condition": "procedure_done = 2",
-                        "value": "Mammogram"
-                    },
-                    {
-                        "condition": "procedure_done = 3",
-                        "value": "Core Needle Biopsy"
-                    },
-                    {
-                        "condition": "procedure_done = 4",
-                        "value": "FNA"
-                    },
-                    {
-                        "condition": "procedure_done = 5",
-                        "value": "Surgical Biopsy"
-                    },
-                    {
-                        "condition": "procedure_done = 6",
-                        "value": "Incisional Biopsy"
-                    }
-                ]
-            }
-
-        },
-        {
-            "type": "derived_column",
-            "alias": "diagnosis",
-            "expressionType": "case_statement",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "diagnosis in (9618,6544,6250,6243,2220,115)",
-                        "value": "1"
-                    },
-                    {
-                        "condition": "else",
-                        "value": "null"
-                    }]
-                    }
-        },
-        {
-            "type": "derived_column",
-            "alias": "cancer_stage",
-            "expressionOptions": {
-                "caseOptions": [
-                    {
-                        "condition": "cancer_staging = 1",
-                        "value": "Stage I"
-                    },
-                    {
-                        "condition": "else",
-                        "value": "null"
-                    },
-                    {
-                        "condition": "cancer_staging = 2",
-                        "value": "Stage II"
-                    },
-                    {
-                        "condition": "cancer_staging = 3",
-                        "value": "Stage III"
-                    },
-                    {
-                        "condition": "cancer_staging = 4",
-                        "value": "Stage IV"
-                    }
-                ]
-            }
-
-        }
-    ],
-    "groupBy":{
-        "columns":["t1.person_id"]
+  "name": "breast_cancer_patient_list_template",
+  "version": "1.0",
+  "tag": "breast_cancer_patient_list_template",
+  "description": "Breast Cancer patient list template",
+  "sources": [
+    {
+      "table": "amrs.person",
+      "alias": "t1"
+    },
+    {
+      "table": "amrs.person_name",
+      "alias": "person_name",
+      "join": {
+        "type": "INNER",
+        "joinCondition": "t1.person_id = person_name.person_id AND (person_name.voided IS NULL || person_name.voided = 0)"
+      }
+    },
+    {
+      "table": "amrs.patient_identifier",
+      "alias": "id",
+      "join": {
+        "type": "LEFT",
+        "joinCondition": "t1.person_id = id.patient_id AND (id.voided IS NULL || id.voided = 0)"
+      }
     }
+  ],
+  "columns": [
+    {
+      "type": "simple_column",
+      "alias": "patient_uuid",
+      "column": "t1.uuid"
+    },
+    {
+      "type": "simple_column",
+      "alias": "person_id",
+      "column": "t1.person_id"
+    },
+    {
+      "type": "simple_column",
+      "alias": "gender",
+      "column": "t1.gender"
+    },
+    {
+      "type": "simple_column",
+      "alias": "birthdate",
+      "column": "t1.birthdate"
+    },
+    {
+      "type": "derived_column",
+      "alias": "age",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "extract(year from (from_days(datediff(now(),t1.birthdate))))"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_status",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "case when hiv_status=1 then 'HIV Negative' when hiv_status=2 then 'HIV Positive' when hiv_status=3 then 'Unknown' else NULL end"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "person_name",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": " CONCAT(COALESCE(person_name.given_name, ''), ' ', COALESCE(person_name.middle_name, ''), ' ', COALESCE(person_name.family_name, ''))"
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "given_name",
+      "column": "person_name.given_name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "family_name",
+      "column": "person_name.family_name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "middle_name",
+      "column": "person_name.middle_name"
+    },
+    {
+      "type": "derived_column",
+      "alias": "identifiers",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": " GROUP_CONCAT(DISTINCT id.identifier SEPARATOR ', ')"
+      }
+    },
+    {
+      "type": "simple_column",
+      "alias": "date_patient_informed_of_results",
+      "column": "date_patient_informed_and_referred_for_management"
+    },
+    {
+      "type": "derived_column",
+      "alias": "diagnostic_interval",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "timestampdiff(day,date(encounter_datetime),date(date_patient_informed_and_referred_for_management))"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "procedure_done",
+      "expressionType": "case_statement",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "procedure_done = 1",
+            "value": "Ultrasound"
+          },
+          {
+            "condition": "procedure_done = 2",
+            "value": "Mammogram"
+          },
+          {
+            "condition": "procedure_done = 3",
+            "value": "Core Needle Biopsy"
+          },
+          {
+            "condition": "procedure_done = 4",
+            "value": "FNA"
+          },
+          {
+            "condition": "procedure_done = 5",
+            "value": "Surgical Biopsy"
+          },
+          {
+            "condition": "procedure_done = 6",
+            "value": "Incisional Biopsy"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "diagnosis",
+      "expressionType": "case_statement",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "diagnosis in (9618,6544,6250,6243,2220,115)",
+            "value": "1"
+          },
+          {
+            "condition": "else",
+            "value": "null"
+          }
+        ]
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "cancer_stage",
+      "expressionOptions": {
+        "caseOptions": [
+          {
+            "condition": "cancer_staging = 1",
+            "value": "Stage I"
+          },
+          {
+            "condition": "else",
+            "value": "null"
+          },
+          {
+            "condition": "cancer_staging = 2",
+            "value": "Stage II"
+          },
+          {
+            "condition": "cancer_staging = 3",
+            "value": "Stage III"
+          },
+          {
+            "condition": "cancer_staging = 4",
+            "value": "Stage IV"
+          }
+        ]
+      }
+    }
+  ],
+  "groupBy": {
+    "columns": [
+      "t1.person_id"
+    ]
+  }
 }

--- a/app/reporting-framework/json-reports/cervical-cancer-daily-screening-summary-aggregate.json
+++ b/app/reporting-framework/json-reports/cervical-cancer-daily-screening-summary-aggregate.json
@@ -3,16 +3,21 @@
   "version": "1.0",
   "tag": "",
   "description": "",
-  "uses": [{
-    "name": "cervicalCancerMonthlyReportBase",
-    "version": "1.0",
-    "type": "dataset_def"
-  }],
-  "sources": [{
-    "dataSet": "cervicalCancerMonthlyReportBase",
-    "alias": "t1"
-  }],
-  "columns": [{
+  "uses": [
+    {
+      "name": "cervicalCancerMonthlyReportBase",
+      "version": "1.0",
+      "type": "dataset_def"
+    }
+  ],
+  "sources": [
+    {
+      "dataSet": "cervicalCancerMonthlyReportBase",
+      "alias": "t1"
+    }
+  ],
+  "columns": [
+    {
       "type": "simple_column",
       "alias": "location_id",
       "column": "t1.location_id"
@@ -77,6 +82,14 @@
     },
     {
       "type": "derived_column",
+      "alias": "hiv_status",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(person_id)"
+      }
+    },
+    {
+      "type": "derived_column",
       "alias": "hiv_negative",
       "expressionType": "simple_expression",
       "expressionOptions": {
@@ -97,6 +110,78 @@
       "expressionType": "simple_expression",
       "expressionOptions": {
         "expression": "count(hiv_positive)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_over_50)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_over_50)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_over_50)"
       }
     },
     {
@@ -177,6 +262,62 @@
       "expressionType": "simple_expression",
       "expressionOptions": {
         "expression": "count(abnormal_above_70yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "procedures_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(procedures_done)"
+      } 
+    },
+    {
+      "type": "derived_column",
+      "alias": "excisional_biopsies",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(excisional_biopsies_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "cryotherapies",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(cryotherapies_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "leeps",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(leeps_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "polypectomies",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(polypectomies_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "core_needle_biopsies",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(core_needle_biopsies_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "pap_smears",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(pap_smears_done)"
       }
     }
   ],

--- a/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-aggregate.json
+++ b/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-aggregate.json
@@ -82,6 +82,14 @@
     },
     {
       "type": "derived_column",
+      "alias": "hiv_status",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(person_id)"
+      }
+    },
+    {
+      "type": "derived_column",
       "alias": "hiv_negative",
       "expressionType": "simple_expression",
       "expressionOptions": {
@@ -102,6 +110,78 @@
       "expressionType": "simple_expression",
       "expressionOptions": {
         "expression": "count(hiv_positive)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_below_25)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_25_to_49)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_positive_over_50)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_negative_over_50)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(hiv_unknown_over_50)"
       }
     },
     {
@@ -182,6 +262,62 @@
       "expressionType": "simple_expression",
       "expressionOptions": {
         "expression": "count(abnormal_above_70yrs)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "procedures_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(procedures_done)"
+      } 
+    },
+    {
+      "type": "derived_column",
+      "alias": "excisional_biopsies",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(excisional_biopsies_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "cryotherapies",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(cryotherapies_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "leeps",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(leeps_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "polypectomies",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(polypectomies_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "core_needle_biopsies",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(core_needle_biopsies_done)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "pap_smears",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "count(pap_smears_done)"
       }
     }
   ],

--- a/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-base.json
+++ b/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-base.json
@@ -317,6 +317,62 @@
     },
     {
       "type": "derived_column",
+      "alias": "procedures_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(via_procedure_done != 1, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "excisional_biopsies_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(via_procedure_done = 2, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "cryotherapies_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(via_procedure_done = 3, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "leeps_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(via_procedure_done = 4, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "polypectomies_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(via_procedure_done = 5, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "core_needle_biopsies_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(via_procedure_done = 6, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "pap_smears_done",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(via_procedure_done = 7, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
       "alias": "via_procedure_done",
       "expressionType": "simple_expression",
       "expressionOptions": {
@@ -501,6 +557,78 @@
       "expressionType": "simple_expression",
       "expressionOptions": {
         "expression": "if(fccs.hiv_status = 2, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 2 and age < 25, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 1 and age < 25, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_below_25",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 3 and age < 30, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 2 and age >= 25 and age < 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 1 and age >= 25 and age < 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_25_to_49",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 3 and age >= 25 and age < 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_positive_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 3 and age > 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_negative_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 1 and age > 50, 1, null)"
+      }
+    },
+    {
+      "type": "derived_column",
+      "alias": "hiv_unknown_over_50",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if(fccs.hiv_status = 3 and age > 50, 1, null)"
       }
     },
     {

--- a/oncology-reports/oncology-patient-list-cols.json
+++ b/oncology-reports/oncology-patient-list-cols.json
@@ -377,19 +377,6 @@
         ]
       },
       {
-        "indicator": "biopsy_results_within_2wks",
-        "patientListCols": [
-          "encounter_datetime",
-          "location_name",
-          "identifiers",
-          "person_name",
-          "gender",
-          "age",
-          "phone_number",
-          "patient_uuid"
-        ]
-      },
-      {
         "indicator": "male_patients",
         "patientListCols": [
           "encounter_datetime",
@@ -452,6 +439,146 @@
           "age",
           "phone_number",
           "patient_uuid"
+        ]
+      },
+      {
+        "indicator": "hiv_positive_below_25",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "hiv_negative_below_25",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "hiv_unknown_below_25",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "hiv_positive_25_to_49",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "hiv_unknown_25_to_49",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "hiv_negative_25_to_49",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "hiv_unknown_over_50",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "hiv_positive_over_50",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "hiv_negative_over_50",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
+        ]
+      },
+      {
+        "indicator": "hiv_unknown_over_50",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status"
         ]
       }
     ]
@@ -780,7 +907,9 @@
           "gender",
           "age",
           "phone_number",
-          "patient_uuid"
+          "patient_uuid",
+          "type_of_abnormality",
+          "via_procedure_done"
         ]
       },
       {
@@ -793,7 +922,9 @@
           "gender",
           "age",
           "phone_number",
-          "patient_uuid"
+          "patient_uuid",
+          "type_of_abnormality",
+          "via_procedure_done"
         ]
       },
       {
@@ -806,7 +937,9 @@
           "gender",
           "age",
           "phone_number",
-          "patient_uuid"
+          "patient_uuid",
+          "type_of_abnormality",
+          "via_procedure_done"
         ]
       },
       {
@@ -819,7 +952,265 @@
           "gender",
           "age",
           "phone_number",
-          "patient_uuid"
+          "patient_uuid",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "hiv_positive_below_25",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "hiv_negative_below_25",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "hiv_unknown_below_25",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "hiv_positive_25_to_49",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "hiv_negative_25_to_49",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "hiv_unknown_25_to_49",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "hiv_positive_over_50",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "hiv_negative_over_50",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "hiv_unknown_over_50",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "procedures_done",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "excisional_biopsies",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "cryotherapies",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "leeps",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "polypectomies",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "core_needle_biopsies",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
+        ]
+      },
+      {
+        "indicator": "pap_smears",
+        "patientListCols": [
+          "encounter_datetime",
+          "location_name",
+          "identifiers",
+          "person_name",
+          "gender",
+          "age",
+          "phone_number",
+          "patient_uuid",
+          "hiv_status",
+          "type_of_abnormality",
+          "via_procedure_done"
         ]
       }
     ]


### PR DESCRIPTION
Add HIV status disaggregation by age to the oncology reports so that data about clients' HIV status in various age segments can be derived. These age segments are:

- Under 25 years
- 25 - 49 years
- Over 50 years

The HIV statuses that ought to be shown are:

- HIV Positive
- HIV Negative
- HIV Status Unknown