### PR TITLE
POCONC-174: Patients aged 70 yrs old not appearing in patient lists

### DIFF
--- a/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-base.json
+++ b/app/reporting-framework/json-reports/breast-cancer-monthly-screening-summary-base.json
@@ -172,7 +172,7 @@
             "alias": "normal_breast_screening_findings_above_70yrs",
             "expressionType": "simple_expression",
             "expressionOptions": {
-            "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age > 70, 1, null)"
+            "expression": "if((cur_physical_findings = 0 or cur_physical_findings is null) and age >= 70, 1, null)"
                        }
         },
         {
@@ -220,7 +220,7 @@
             "alias": "abnormal_breast_screening_findings_above_70yrs",
             "expressionType": "simple_expression",
             "expressionOptions": {
-            "expression": "if(cur_physical_findings != 0 and age > 70, 1, null)"
+            "expression": "if(cur_physical_findings != 0 and age >= 70, 1, null)"
                        }
         },
         {

--- a/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-base.json
+++ b/app/reporting-framework/json-reports/cervical-cancer-monthly-screening-summary-base.json
@@ -211,7 +211,7 @@
             "alias": "abnormal_cervical_screening_above_70yrs",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(fccs.cur_via_result != 1 and age > 70, 1, null)"
+                "expression": "if(fccs.cur_via_result != 1 and age >= 70, 1, null)"
             }
         },
         {
@@ -259,7 +259,7 @@
             "alias": "normal_cervical_screening_above_70yrs",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age > 70, 1, null)"
+                "expression": "if((fccs.cur_via_result = 1 or fccs.cur_via_result is null) and age >= 70, 1, null)"
             }
         },
         {


### PR DESCRIPTION
A bug with the logic used to disaggregate breast and cervical screening findings by age is causing patients aged exactly 70 years old not to appear on the aggregate report counts as well as the patient lists. The check currently being used to determine whether a patient is in the over 70 years age segment only checks for whether the patient's age is above 70 years old. Patients aged 70 are being bypassed by that check.