### PR TITLE
POCONC-190: Modify lung cancer screening report columns

### DIFF
--- a/app/reporting-framework/json-reports/lung-cancer-monthly-screening-summary-aggregate.json
+++ b/app/reporting-framework/json-reports/lung-cancer-monthly-screening-summary-aggregate.json
@@ -72,7 +72,7 @@
             "alias": "tobacco_use",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "count(tobacco_use)"
+                "expression": "count(uses_tobacco)"
             }
         },
         {

--- a/app/reporting-framework/json-reports/lung-cancer-monthly-screening-summary-base.json
+++ b/app/reporting-framework/json-reports/lung-cancer-monthly-screening-summary-base.json
@@ -124,15 +124,15 @@
             "alias": "cigarette_smoking",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(ever_smoked_cigarettes = 1, 1, NULL)"
+                "expression": "if(smokes_cigarettes = 1, 1, NULL)"
             }
         },        
         {
             "type": "derived_column",
-            "alias": "tobacco_use",
+            "alias": "uses_tobacco",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(tobacco_use = 1 or tobacco_use = 3 , 1, NULL)"
+                "expression": "if(uses_tobacco = 1 or uses_tobacco = 3 , 1, NULL)"
             }
         },        
         {
@@ -174,31 +174,31 @@
             "expressionOptions": {
                 "caseOptions": [
                     {
-                        "condition": "referral_from = 1",
+                        "condition": "referred_from = 1",
                         "value": "Radiology"
                     },
                     {
-                        "condition": "referral_from = 2",
+                        "condition": "referred_from = 2",
                         "value": "Pulmonary clinic"
                     },
                     {
-                        "condition": "referral_from = 3",
+                        "condition": "referred_from = 3",
                         "value": "Private health sector"
                     },
                     {
-                        "condition": "referral_from = 4",
+                        "condition": "referred_from = 4",
                         "value": "Self"
                     },
                     {
-                        "condition": "referral_from = 5",
+                        "condition": "referred_from = 5",
                         "value": "Tuberculosis treatment or dot program"
                     },
                     {
-                        "condition": "referral_from = 6",
+                        "condition": "referred_from = 6",
                         "value": "Health centre hospitals"
                     },
                     {
-                        "condition": "referral_from = 7",
+                        "condition": "referred_from = 7",
                         "value": "Other non-coded"
                     }
                 ]
@@ -217,7 +217,7 @@
             "alias": "tb_treatment_received",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(previous_tb_treatment = 1 , 1, NULL)"
+                "expression": "if(previous_treatment_for_tuberculosis = 1 , 1, NULL)"
             }
         },
         {
@@ -225,7 +225,7 @@
             "alias": "no_tb_treatment",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(previous_tb_treatment = 2 , 1, NULL)"
+                "expression": "if(previous_treatment_for_tuberculosis = 2 , 1, NULL)"
             }
         },
         {
@@ -233,7 +233,7 @@
             "alias": "normal_xray_results",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(x_ray_results = 1 , 1, NULL)"
+                "expression": "if(chest_xray_results = 1 , 1, NULL)"
             }
         },
         {
@@ -241,7 +241,7 @@
             "alias": "abnormal_xray_results",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(x_ray_results = 2 , 1, NULL)"
+                "expression": "if(chest_xray_results = 2 , 1, NULL)"
             }
         },
         {
@@ -249,7 +249,7 @@
             "alias": "biopsy_done",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(biospy_procedure_done = 1 , 1, NULL)"
+                "expression": "if(was_biopsy_procedure_done = 1 , 1, NULL)"
             }
         },
         {
@@ -257,7 +257,7 @@
             "alias": "biopsy_not_done",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(biospy_procedure_done = 2 , 1, NULL)"
+                "expression": "if(was_biopsy_procedure_done = 2 , 1, NULL)"
             }
         },
         {
@@ -265,7 +265,7 @@
             "alias": "non_respiratory_disease",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(repository_disease = 1 or repository_disease = 2 or repository_disease = 3 or repository_disease = 4 or repository_disease = 5, 1, NULL)"
+                "expression": "if(non_cancer_respiratory_disease_type = 1 or non_cancer_respiratory_disease_type = 2 or non_cancer_respiratory_disease_type = 3 or non_cancer_respiratory_disease_type = 4 or non_cancer_respiratory_disease_type = 5, 1, NULL)"
             }
         },
         {
@@ -289,7 +289,7 @@
             "alias": "biopsy_result",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "case when (select biospy_results from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 1 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'MALIGNANT' when (select biospy_results from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 2 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'NON-CANCER RESPIRATORY DISEASE' when (select biospy_results from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 3 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'OTHER NON CODED'  else 'null' end"
+                "expression": "case when (select lung_biopsy_results from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 1 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'MALIGNANT' when (select lung_biopsy_results from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 2 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'NON-CANCER RESPIRATORY DISEASE' when (select lung_biopsy_results from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 3 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'OTHER NON CODED'  else 'null' end"
             }
         },
         {
@@ -297,7 +297,7 @@
             "alias": "indication_of_lung_mass_from_ct_findings",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(((select ct_findings from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1) = 1) , 1, NULL)"
+                "expression": "if(((select chest_ct_scan_findings from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1) = 1) , 1, NULL)"
             }
         },
         {
@@ -305,7 +305,7 @@
             "alias": "indication_of_mediastial_mass_from_ct_findings",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(((select ct_findings from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id and(select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1) = 2) , 1, NULL)"
+                "expression": "if(((select chest_ct_scan_findings from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id and(select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1) = 2) , 1, NULL)"
             }
         },
         {
@@ -313,7 +313,7 @@
             "alias": "indication_of_pleural_mass_from_ct_findings",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "if(((select ct_findings from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id and(select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1) = 3) , 1, NULL)"
+                "expression": "if(((select chest_ct_scan_findings from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id and(select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1) = 3) , 1, NULL)"
             }
         },
         {
@@ -337,7 +337,7 @@
             "alias": "type_of_non_cancer_respiratory_diseases",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "case when (select repository_disease from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 1 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'CHRONIC OBSTRUCTIVE PULMONARY DISEASE' when (select repository_disease from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 2 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'TUBERCULOSIS' when (select repository_disease from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 3 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'ASPERGILLOSIS' when (select repository_disease from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 4 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'GRANULOMATOSIS' when (select repository_disease from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 5 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'OTHER NON-CODED'  else 'null' end"
+                "expression": "case when (select non_cancer_respiratory_disease_type from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 1 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'CHRONIC OBSTRUCTIVE PULMONARY DISEASE' when (select non_cancer_respiratory_disease_type from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 2 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'TUBERCULOSIS' when (select non_cancer_respiratory_disease_type from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 3 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'ASPERGILLOSIS' when (select non_cancer_respiratory_disease_type from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 4 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'GRANULOMATOSIS' when (select non_cancer_respiratory_disease_type from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 5 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'OTHER NON-CODED'  else 'null' end"
             }
         },
         {
@@ -353,7 +353,7 @@
             "alias": "referrals",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "case when (select referral_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 1 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'LUNG CANCER CLINIC' when (select referral_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 2 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'PULMONARY CLINIC' when (select referral_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 3 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'PALLIATIVE CARE' when (select referral_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 4 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'SOCIAL SUPPORT SERVICES' when (select referral_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 5 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'REPEAT PROCEDURE' when (select referral_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 6 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'REFERRAL FOR RADIATION THERAPY' when (select referral_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 7 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'OTHER NON-CODED'  else 'null' end"
+                "expression": "case when (select referrals_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 1 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'LUNG CANCER CLINIC' when (select referrals_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 2 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'PULMONARY CLINIC' when (select referrals_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 3 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'PALLIATIVE CARE' when (select referrals_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 4 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'SOCIAL SUPPORT SERVICES' when (select referrals_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 5 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'REPEAT PROCEDURE' when (select referrals_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 6 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'REFERRAL FOR RADIATION THERAPY' when (select referrals_ordered from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) = 7 and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) then 'OTHER NON-CODED'  else 'null' end"
             }
         },
         {
@@ -361,7 +361,7 @@
             "alias": "imaging_results_description",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "(select Imaging_results_description from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1)"
+                "expression": "(select imaging_results_description from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id and (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 185 and person_id = p.person_id order by encounter_datetime desc limit 1) > (select encounter_datetime from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1)"
             }
         },
         {
@@ -369,7 +369,7 @@
             "alias": "pack_years",
             "expressionType": "simple_expression",
             "expressionOptions": {
-                "expression": "(select number_of_sticks from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id / 20 * (select number_of_years from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1)"
+                "expression": "(select sticks_smoked_per_day from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id / 20 * (select years_of_smoking_cigarettes from etl.flat_lung_cancer_screening where encounter_type = 177 and person_id = p.person_id order by encounter_datetime desc limit 1) order by encounter_datetime desc limit 1)"
             }
         }
     ],


### PR DESCRIPTION
Minor amendments to some lung cancer screening report following changes to the associated stored procedure. These include:

- Rename `tobacco_use` to `uses_tobacco`.
- Rename `referral_from` to `referred_from`.
- Rename `x_ray_results` to `chest_xray_results`.
- Rename `repository_disease` to `non_cancer_respiratory_disease_type`.
- Rename `biopsy_results` to `lung_biopsy_results`.
- Rename `ever_smoked_cigarettes` to `smokes_cigarettes`.
- Rename `biospy_procedure_done` to `biopsy_procedure_done`.
- Rename `number_of_sticks` to `sticks_smoked_per_day`.
- Rename `number_of_years`to `years_of_smoking_cigarettes`.
- Rename `staging` to `cancer_staging`.
- Rename `previous_tb_treatment` to `previous_treatment_for_tuberculosis`.
- Rename `ct_findings` to `chest_ct_scan_findings`.
- Rename `referral_ordered`to `referrals_ordered`.