### PR TITLE
POCONC-192: Fix shared referral patient lists

### DIFF
--- a/app/reporting-framework/base-mysql.report.js
+++ b/app/reporting-framework/base-mysql.report.js
@@ -35,6 +35,8 @@ import * as ever_on_art_base from './json-reports/ever-on-art-base.json';
 import * as referral_patient_list_template from './json-reports/referral-patient-list-template.json';
 import * as referral_dataset_base from './json-reports/referral-dataset-base.json';
 import * as referral_aggregate from './json-reports/referral-aggregate.json';
+import * as referral_peer_aggregate from './json-reports/referral-peer-aggregate.json';
+import * as referral_patient_list_peer_base from './json-reports/referral-peer-base.json';
 import * as cdm_dataset_base from './json-reports/cdm/cdm-dataset-base.json';
 
 import * as starting_art_aggregation_age15 from './json-reports/starting-art-aggregation-age15.json';
@@ -133,12 +135,9 @@ import * as retention_intervention_cohort from './json-reports/retention-interve
 import * as retention_ltfu_base from './json-reports/retention-ltfu-base.json';
 import * as retention_ltfu_aggregate from './json-reports/retention-ltfu-aggregate.json';
 
-
 import * as surge_report_base from './json-reports/surge-report-base.json';
 import * as surge_report_aggregate from './json-reports/surge-report-aggregate.json';
 
-import * as referral_patient_list_peer_base from './json-reports/referral-peer-base';
-import * as referral_peer_aggregate from './json-reports/referral-peer-aggregate';
 import * as surge_daily_report_base from './json-reports/surge-daily-report-base';
 import * as surge_daily_report_aggregate from './json-reports/surge-daily-report-aggregate';
 import * as surge from './json-reports/surge-report.json';
@@ -421,6 +420,12 @@ export class BaseMysqlReport {
                         referralDatasetbase: this.cloneJsonSchema(referral_dataset_base)
                     });
                     break;
+                case 'referral-patient-peer-navigator-list':
+                    resolve({
+                        main: this.cloneJsonSchema(referral_peer_aggregate),
+                        referralDatasetbase: this.cloneJsonSchema(referral_patient_list_peer_base)
+                    });
+                    break;
                 case 'StartingARTAggregationAge15':
                     resolve({
                         main: this.cloneJsonSchema(starting_art_aggregation_age15),
@@ -588,12 +593,6 @@ export class BaseMysqlReport {
                     resolve({
                         main: this.cloneJsonSchema(surge_report_aggregate),
                         surgeReport: this.cloneJsonSchema(surge_report_base)
-                    });
-                    break;
-                case 'referral-patient-peer-navigator-list':
-                    resolve({
-                        main: this.cloneJsonSchema(referral_peer_aggregate),
-                        referralDatasetbase: this.cloneJsonSchema(referral_patient_list_peer_base)
                     });
                     break;
                 case 'surgeDailyReport':

--- a/app/reporting-framework/json-reports/referral-dataset-base.json
+++ b/app/reporting-framework/json-reports/referral-dataset-base.json
@@ -1,165 +1,159 @@
 {
-    "name": "referralDataSetbase",
-    "version": "1.0",
-    "tag": "",
-    "description": "",
-    "uses": [],
-    "sources": [
-
-        {
-            "table": "amrs.patient_program",
-            "alias": "t3"
-        },
-        {
-            "table": "etl.flat_cdm_peer_navigation",
-            "alias": "n",
-            "join": {
-                "type": "LEFT",
-                "joinCondition": "n.person_id  = t3.patient_id"
-            }
-        },         
-        {
-            "table": "amrs.program",
-            "alias": "t5",
-            "join": {
-                "type": "INNER",
-                "joinCondition": "t3.program_id = t5.program_id"
-            }
-        },
-        {
-            "table": "amrs.location",
-            "alias": "t9",
-            "join": {
-                "type": "INNER",
-                "joinCondition": "t3.location_id = t9.location_id"
-            }
-        },
-        {
-            "table": "amrs.location",
-            "alias": "location",
-            "join": {
-                "type": "INNER",
-                "joinCondition": "n.location_id = location.location_id"
-            }
-        },
-        {
-            "table": "amrs.location",
-            "alias": "referral_location",
-            "join": {
-              "type": "INNER",
-              "joinCondition": "n.location_id = referral_location.location_id"
-            }
-        }
-    ],
-    "columns": [
-        {
-            "type": "simple_column",
-            "alias": "patient_id",
-            "column": "t3.patient_id"
-        },       
-        {
-            "type": "simple_column",
-            "alias": "program",
-            "column": "t5.name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "referal_urgency",
-            "column": "n.referal_urgency"
-        },
-        {
-            "type": "simple_column",
-            "alias": "initial_or_follow_up",
-            "column": "n.initial_or_follow_up"
-        },
-        {
-            "type": "simple_column",
-            "alias": "encounter_type",
-            "column": "n.encounter_type"
-        },
-        {
-            "type": "simple_column",
-            "alias": "is_referal_completed",
-            "column": "n.is_referal_completed"
-        },
-        {
-            "type": "simple_column",
-            "alias": "are_you_the_referring_or_receiving_peer",
-            "column": "n.are_you_the_referring_or_receiving_peer"
-        },
-        {
-            "type": "simple_column",
-            "alias": "referred_in_or_out",
-            "column": "n.referred_in_or_out"
-        },
-        {
-            "type": "simple_column",
-            "alias": "programUuids",
-            "column": "t5.uuid"
-        },
-        {
-            "type": "simple_column",
-            "alias": "program_id",
-            "column": "t5.program_id"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location",
-            "column": "t9.name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "locationUuids",
-            "column": "t9.uuid"
-        },
-        {
-            "type": "simple_column",
-            "alias": "location_id",
-            "column": "t9.location_id"
-        },
-        {
-            "type": "simple_column",
-            "alias": "referred_from",
-            "column": "location.name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "referred_to",
-            "column": "referral_location.name"
-        },
-        {
-            "type": "simple_column",
-            "alias": "date_referred",
-            "column": "DATE_FORMAT(n.encounter_datetime, '%Y-%m-%d')"
-        }
-    ],
-    "orderBy": {
-        "orderByParam": "orderByParam",
-        "columns": []
+  "name": "referralDataSetbase",
+  "version": "1.0",
+  "tag": "",
+  "description": "",
+  "uses": [],
+  "sources": [
+    {
+      "table": "amrs.patient_program",
+      "alias": "t3"
     },
-    "filters": {
-        "conditionJoinOperator": "and",
-        "conditions": [
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "DATE_FORMAT(n.encounter_datetime, '%Y-%m-%d') >= ?",
-                "parameterName": "startDate"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "DATE_FORMAT(n.encounter_datetime, '%Y-%m-%d') <= ?",
-                "parameterName": "endDate"
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "t9.uuid in (?)",
-                "parameterName": "locationUuids"        
-            },
-            {
-                "filterType": "tableColumns",
-                "conditionExpression": "t5.uuid in  (?)",
-                "parameterName": "programUuids"
-            }
-        ]
+    {
+      "table": "etl.patient_referral",
+      "alias": "t4",
+      "join": {
+        "type": "LEFT",
+        "joinCondition": "t4.patient_program_id  = t3.patient_program_id"
+      }
+    },
+    {
+      "table": "amrs.program",
+      "alias": "t5",
+      "join": {
+        "type": "INNER",
+        "joinCondition": "t3.program_id = t5.program_id"
+      }
+    },
+    {
+      "table": "amrs.location",
+      "alias": "t9",
+      "join": {
+        "type": "INNER",
+        "joinCondition": "t3.location_id = t9.location_id"
+      }
+    },
+    {
+      "table": "amrs.location",
+      "alias": "location",
+      "join": {
+        "type": "INNER",
+        "joinCondition": "t4.referred_from_location_id = location.location_id"
+      }
+    },
+    {
+      "table": "amrs.location",
+      "alias": "referral_location",
+      "join": {
+        "type": "INNER",
+        "joinCondition": "t4.referred_to_location_id = referral_location.location_id"
+      }
+    },
+    {
+      "table": "amrs.person_attribute",
+      "alias": "pa",
+      "join": {
+        "type": "LEFT",
+        "joinCondition": "t3.patient_id = pa.person_id AND (pa.voided IS NULL || pa.voided = 0) AND pa.person_attribute_type_id = 28"
+      }
     }
+  ],
+  "columns": [
+    {
+      "type": "simple_column",
+      "alias": "patient_id",
+      "column": "t3.patient_id"
+    },
+    {
+      "type": "simple_column",
+      "alias": "program",
+      "column": "t5.name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "programUuids",
+      "column": "t5.uuid"
+    },
+    {
+      "type": "simple_column",
+      "alias": "program_id",
+      "column": "t5.program_id"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location",
+      "column": "t9.name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "locationUuids",
+      "column": "t9.uuid"
+    },
+    {
+      "type": "simple_column",
+      "alias": "location_id",
+      "column": "t9.location_id"
+    },
+    {
+      "type": "simple_column",
+      "alias": "referred_from",
+      "column": "location.name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "referred_to",
+      "column": "referral_location.name"
+    },
+    {
+      "type": "simple_column",
+      "alias": "date_referred",
+      "column": "DATE_FORMAT(t4.date_created, '%Y-%m-%d')"
+    },
+    {
+      "type": "derived_column",
+      "alias": "review_status",
+      "expressionType": "simple_expression",
+      "expressionOptions": {
+        "expression": "if (t4.notification_status IS NULL, 'PENDING', 'DONE')"
+      }
+    }
+  ],
+  "orderBy": {
+    "orderByParam": "orderByParam",
+    "columns": [
+      {
+        "column": "t4.notification_status",
+        "order": "asc"
+      }
+    ]
+  },
+  "filters": {
+    "conditionJoinOperator": "and",
+    "conditions": [
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "DATE_FORMAT(t4.date_created, '%Y-%m-%d') >= ?",
+        "parameterName": "startDate"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "DATE_FORMAT(t4.date_created, '%Y-%m-%d') <= ?",
+        "parameterName": "endDate"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "t9.uuid in (?)",
+        "parameterName": "locationUuids"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "t5.uuid in  (?)",
+        "parameterName": "programUuids"
+      },
+      {
+        "filterType": "tableColumns",
+        "conditionExpression": "(pa.value IS NULL || pa.value IS true)"
+      }
+    ]
+  }
 }

--- a/app/reporting-framework/json-reports/referral-peer-base.json
+++ b/app/reporting-framework/json-reports/referral-peer-base.json
@@ -142,7 +142,7 @@
         {
             "type": "simple_column",
             "alias": "referral_urgency",
-            "column": "peer_navigation.referal_category"
+            "column": "peer_navigation.referal_urgency"
         },
         {
             "type": "simple_column",

--- a/etl-routes.js
+++ b/etl-routes.js
@@ -1360,18 +1360,14 @@ module.exports = function () {
                         if (!authorizer.hasReportAccess(request.query.reportName)) {
                             return reply(Boom.forbidden('Unauthorized'));
                         }
-
                         let requestParams = Object.assign({}, request.query, request.params);
                         requestParams.reportName = 'referralAggregate';
                         let service = new PatientReferralService();
-
-                        service.getPatientListReport2(requestParams).then((result) => {
-
+                        service.getReferralPatientListReport(requestParams).then((result) => {
                             reply(result);
                         }).catch((error) => {
                             reply(error);
                         });
-
                     },
                     description: "Get patient referral for selected clinic",
                     notes: "Returns patient referral for the selected clinic(s),start date, end date",
@@ -4567,13 +4563,11 @@ module.exports = function () {
                         if (!authorizer.hasReportAccess(request.query.reportName)) {
                             return reply(Boom.forbidden('Unauthorized'));
                         }
-
                         let requestParams = Object.assign({}, request.query, request.params);
                         requestParams.reportName = 'referral-patient-peer-navigator-list';
                         let service = new PatientReferralService();
 
-                        service.getPatientListReport3(requestParams).then((result) => {
-
+                        service.getPeerNavigatorReferralPatientList(requestParams).then((result) => {
                             reply(result);
                         }).catch((error) => {
                             reply(error);

--- a/service/patient-referral.service.js
+++ b/service/patient-referral.service.js
@@ -1,92 +1,94 @@
-const dao = require('../etl-dao');
+import { PatientlistMysqlReport } from "../app/reporting-framework/patientlist-mysql.report";
+import { PatientReferralAggregateService } from "./patient-referral-aggregate.service";
+import { titleCase } from "../etl-helpers";
+
+const dao = require("../etl-dao");
 const Promise = require("bluebird");
-const Moment = require('moment');
-const _ = require('lodash');
-import {
-    BaseMysqlReport
-} from '../app/reporting-framework/base-mysql.report'
-import {
-    PatientlistMysqlReport
-} from '../app/reporting-framework/patientlist-mysql.report'
-import {
-    PatientReferralAggregateService
-} from './patient-referral-aggregate.service'
+
 export class PatientReferralService {
+  getAggregateReport(reportParams) {
+    reportParams.locationUuids = reportParams.locationUuids
+      ? reportParams.locationUuids.replace(/,/g, "', '")
+      : null;
+    reportParams.programUuids = reportParams.programUuids
+      ? reportParams.programUuids.replace(/,/g, "', '")
+      : null;
+    reportParams.notificationStatus = reportParams.notificationStatus
+      ? null
+      : "null";
+    return new Promise(function (resolve, reject) {
+      reportParams.groupBy = "groupByLocation,groupByProgram";
+      reportParams.countBy = "num_persons";
+      let report = new PatientReferralAggregateService(
+        "referralAggregate",
+        reportParams
+      );
+      Promise.join(report.generateReport(reportParams), (results) => {
+        results = results.results;
+        resolve(results);
+      }).catch((errors) => {
+        reject(errors);
+      });
+    });
+  }
 
+  getPatientListReport(reportParams) {
+    return new Promise(function (resolve, reject) {
+      reportParams.groupBy = "groupByPerson";
+      Promise.join(dao.runReport(reportParams), (results) => {
+        resolve(results);
+      }).catch((errors) => {
+        reject(errors);
+      });
+    });
+  }
 
-    getAggregateReport(reportParams) {
-        reportParams.locationUuids = reportParams.locationUuids ? reportParams.locationUuids.replace(/,/g, "','") : null;
-        reportParams.programUuids = reportParams.programUuids ? reportParams.programUuids.replace(/,/g, "','") : null;
-        // notificationStatus param can either be ALL or null
-        // notificationStatus param with ALL is used to get all patients irrespective of notification status
-        // if notificationStatus is not provided : only  patients notification with null notification status are included
-        reportParams.notificationStatus = reportParams.notificationStatus ? null : 'null';
-        let self = this;
-        return new Promise(function (resolve, reject) {
-            reportParams.groupBy = 'groupByLocation,groupByProgram';
-            reportParams.countBy = 'num_persons';
-            let report = new PatientReferralAggregateService('referralAggregate', reportParams);
-            Promise.join(report.generateReport(reportParams),
-                (results) => {
-                    // TODO Do some post processing
-                    results = results.results;
-                    resolve(results);
-                }).catch((errors) => {
-                reject(errors);
-            });
-        });
-    }
+  getReferralPatientListReport(reportParams) {
+    return new Promise(function (resolve, reject) {
+      reportParams.groupBy = "groupByPerson";
+      reportParams.notificationStatus = reportParams.notificationStatus
+        ? null
+        : "null";
+      let reportName = reportParams.reportName;
+      let report = new PatientlistMysqlReport(reportName, reportParams);
 
-    getPatientListReport(reportParams) {
-        let self = this;
-        return new Promise(function (resolve, reject) {
-            reportParams.groupBy = 'groupByPerson';
-            //TODO: Do some pre processing
-            Promise.join(dao.runReport(reportParams),
-                (results) => {
-                    resolve(results);
-                }).catch((errors) => {
-                reject(errors);
-            });
-        });
-    }
+      Promise.join(report.generatePatientListReport([]), (data) => {
+        const { results } = data.results;
+        for (let key in results) {
+          if (results.hasOwnProperty(key)) {
+            if (results[key].person_name) {
+              results[key].person_name = titleCase(results[key].person_name);
+            }
+          }
+        }
+        let reportData = {};
+        reportData.result = results.sort((a, b) =>
+          b.date_referred > a.date_referred ? 1 : -1
+        );
+        resolve(reportData);
+      }).catch((errors) => {
+        reject(errors);
+      });
+    });
+  }
 
-    getPatientListReport2(reportParams) {
-        // let self = this;
-        return new Promise(function (resolve, reject) {
-            reportParams.groupBy = 'groupByPerson';
-            reportParams.notificationStatus = reportParams.notificationStatus ? null : 'null';
-            let report = new PatientlistMysqlReport('referralAggregate', reportParams);
-            Promise.join(report.generatePatientListReport([]),
-                (results) => {
-                    // results.result = results.results.results;
-                    let data = results;
-                    data.result = results.results.results;
-                    // let data = results.results.results;
-                    resolve(data);
-                })
-                .catch((errors) => {
-                    reject(errors);
-                });
-        });
-      }
-    getPatientListReport3(reportParams) {
-        // let self = this;
-        return new Promise(function (resolve, reject) {
-            reportParams.groupBy = 'groupByPerson';
-            reportParams.notificationStatus = reportParams.notificationStatus ? null : 'null';
-            let report = new PatientlistMysqlReport('referral-patient-peer-navigator-list', reportParams);
-            Promise.join(report.generatePatientListReport([]),
-                (results) => {
-                    // results.result = results.results.results;
-                    let data = results;
-                    data.result = results.results.results;
-                    // let data = results.results.results;
-                    resolve(data);
-                })
-                .catch((errors) => {
-                    reject(errors);
-                });
-        });
-    }
+  getPeerNavigatorReferralPatientList(reportParams) {
+    return new Promise(function (resolve, reject) {
+      reportParams.groupBy = "groupByPerson";
+      reportParams.notificationStatus = reportParams.notificationStatus
+        ? null
+        : "null";
+      let report = new PatientlistMysqlReport(
+        "referral-patient-peer-navigator-list",
+        reportParams
+      );
+      Promise.join(report.generatePatientListReport([]), (results) => {
+        let data = results;
+        data.result = results.results.results;
+        resolve(data);
+      }).catch((errors) => {
+        reject(errors);
+      });
+    });
+  }
 }


### PR DESCRIPTION
Presently, referral patient lists (_found under Clinic Dashboard > Patient Referral_) for the Hemato-Oncology and CDM departments are not working as they should.

The logic for this feature was written such that both departments could reuse the same base and aggregate reports, as well as displaying the same report indicators in the UI. The shared URL endpoint for these reports was modified at some point, which is why they stopped working. The aim of this change was likely to try and get the peer navigator tracking patient list used by the CDM department working. Currently, neither the peer navigator tracking patient list nor the referral patient lists are working in production.

This PR sets the URL endpoint back to the appropriate one and gets the referral patient lists back working again. It also:

- Adds a check to ensure that test patients do not appear in the patient lists.
- Enhances readability by formatting clients' names to title case.
- Sorts referrals by `date referred` in descending order.

**Note**: This PR does not fix the peer navigator tracking patient list.