### PR TITLE
Reduce number of requests to kemri Alupe Lab

### DIFF
--- a/dao/eid/eid-patient-last-order-location.js
+++ b/dao/eid/eid-patient-last-order-location.js
@@ -1,0 +1,25 @@
+import QueryService from '../../app/database-access/query.service';
+
+export class PatientLastOrderLocationDao {
+
+    constructor() { }
+
+    getPatientLastOrderLocation(patientUuid) {
+        let runner = new QueryService();
+
+        let sqlQuery = `SELECT e.location_id as location FROM amrs.encounter e
+        LEFT JOIN amrs.orders o on o.encounter_id = e.encounter_id
+        INNER JOIN amrs.person p on o.patient_id = p.person_id
+        WHERE p.uuid = '`+patientUuid+`' ORDER BY e.encounter_datetime DESC LIMIT 1;`;
+
+        return new Promise((resolve, reject) => {
+            runner.executeQuery(sqlQuery)
+                .then((result) => {
+                    resolve({ result: result });
+                })
+                .catch((error) => {
+                    reject(error)
+                });
+        });
+    }
+}


### PR DESCRIPTION
- Restrict patients whose last order location is not affiliated to Alupe Lab from making requests to the lab. They should only sync from the Ampath lab.