### PR TITLE
Increase PEP visit validation duration period to 60 days

### DIFF
--- a/programs/scope-builder.service.js
+++ b/programs/scope-builder.service.js
@@ -117,8 +117,8 @@ function isInitialPepVisit(patientEncounters) {
 
     let latestPEPEncounterDate = Moment(latestPEPEncounter.encounterDatetime).format();
     duration = today.diff(latestPEPEncounterDate,'days');
-    // if its more than 28 days since their last PEP Initial then they should see a pep initial visit
-    if(duration > 28){
+    // if its more than 60 days since their last PEP Initial then they should see a pep initial visit
+    if(duration > 60){
         isInitialPEPVisit = true;
     }else{
        isInitialPEPVisit = false;


### PR DESCRIPTION
This PR increases the validation period for PEP initial visits from 28 to 60 days i.e. clients should be eligible for a PEP initial visit if they return to clinic 60 days or later since their first PEP initial.