### PR TITLE
Point travis status badge to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/AMPATH/etl-rest-server.svg?branch=master)](https://travis-ci.org/AMPATH/etl-rest-server)
+[![Build Status](https://travis-ci.com/AMPATH/etl-rest-server.svg?branch=master)](https://travis-ci.com/AMPATH/etl-rest-server)
 
 # ETL REST Server
 


### PR DESCRIPTION
This PR modifies the Travis status badge URLs to point to the new [domain](https:travis-ci.com) following the migration of this repo's CI.