### PR TITLE
Add lint step to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     packages:
       - g++-5
 script:
+  - npm run prettier:check
   - npm test
   - npm start
 env:


### PR DESCRIPTION
This PR adds a lint step to Travis that checks that all code pushed to the repo matches the formatting style defined in our barebones (default) config. Now that all files are formatted, it would be wise to keep the repo pristine.