### PR TITLE
Add json to lint-staged glob patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,css,md}": "prettier --write"
+    "*.{js,css,md,json}": "prettier --write"
   },
   "pre-commit": "npm test",
   "author": "AMPATH DEVS",


### PR DESCRIPTION
Add `json` file format to the glob patterns considered by lint-staged for automatic formatting pre-commit. Solves the problem of json files with lint errors breaking CI builds.