### PR TITLE
Rename CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: etl-rest-server CI
+name: POC CI
 on:
   push:
     branches: [master]


### PR DESCRIPTION
I think `POC` is a better name as it suitably encompasses what `ng2-amrs` and `etl-rest-server` do.

Relates to: https://github.com/AMPATH/ng2-amrs/pull/1371