### PR TITLE
Run prettier check pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     }
   },
   "lint-staged": {
-    "*.{js,css,md,json}": "prettier --write"
+    "*.{js,css,md,json}": [
+      "prettier --write",
+      "prettier --check"
+    ]
   },
   "pre-commit": "npm test",
   "author": "AMPATH DEVS",


### PR DESCRIPTION
It's pretty annoying to have your PR fail a CI status check because Prettier didn't run on your staged files pre-commit. This PR fixes that by explicitly calling `prettier --check` in the pre-commit hook.