### PR TITLE
Rework ETL Rest server Authentication mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ etl-daemon.js
 coverage
 conf/config-bk.json
 .DS_Store
+conf/config-live.json

--- a/etl-routes.js
+++ b/etl-routes.js
@@ -88,7 +88,7 @@ module.exports = (function () {
           hapiAuthorization: false
         },
         handler: function (request, reply) {
-          console.log('default rote', request.path);
+          console.log('default route', request.path);
 
           reply('Welcome to Ampath ETL service.');
           //return reply(Boom.forbidden('Not this end point bruh'));
@@ -710,7 +710,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/defaulter-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           if (request.query.locationUuids) {
             request.query.reportName = 'defaulter-list';
@@ -771,7 +771,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{patientUuids}/cdm-summary',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -811,7 +811,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{patientUuids}/medication-change',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -851,7 +851,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{patientUuid}/hiv-clinical-reminder/{referenceDate}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -984,7 +984,7 @@ module.exports = (function () {
       method: 'POST',
       path: '/etl/forms/error',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           dao.logError(request, reply);
         }
@@ -1024,7 +1024,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{uuid}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1039,7 +1039,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/program-visit-configs',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           // var requestParams = Object.assign({}, request.query, request.params);
@@ -1065,7 +1065,7 @@ module.exports = (function () {
       path:
         '/etl/patient/{patientUuid}/program/{programUuid}/enrollment/{enrollmentUuid}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1121,7 +1121,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{uuid}/clinical-notes',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1151,7 +1151,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{uuid}/hiv-patient-clinical-summary',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             roles: [privileges.canViewPatient, privileges.canViewDataAnalytics]
@@ -1166,7 +1166,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{id}/hiv-patient-clinical-summary',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             roles: [privileges.canViewPatient, privileges.canViewDataAnalytics]
@@ -1181,7 +1181,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{uuid}/vitals',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1210,7 +1210,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{uuid}/data',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1239,7 +1239,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{uuid}/hiv-summary',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1279,7 +1279,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{uuid}/oncology/summary',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1310,7 +1310,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{uuid}/patient-summary',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1343,7 +1343,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{uuid}/clinic-encounter-data',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -1366,7 +1366,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-program-config',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           var requestParams = Object.assign({}, request.query);
@@ -1403,7 +1403,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{uuid}/monthly-appointment-visits',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -1442,7 +1442,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{uuid}/hiv-summary-indicators',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewDataAnalytics
@@ -1480,7 +1480,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/clinical-hiv-comparative-overview',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewDataAnalytics
@@ -1541,7 +1541,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/clinical-hiv-comparative-overview/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1614,7 +1614,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-referrals',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -1687,7 +1687,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/referral-patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -1756,7 +1756,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-referral-details/{locationUuid}/{enrollmentUuid}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           patientReferralDao
@@ -1781,7 +1781,7 @@ module.exports = (function () {
       method: 'POST',
       path: '/etl/patient-referral',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           patientReferralDao
@@ -1809,7 +1809,7 @@ module.exports = (function () {
       method: 'POST',
       path: '/etl/patient-referral/{patientReferralId}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           // console.log('xxxxxxxxxxxx', request)
@@ -1841,7 +1841,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/clinical-patient-care-status-overview',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewDataAnalytics
@@ -1897,7 +1897,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/clinical-patient-care-status-overview/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -1959,7 +1959,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/clinical-art-overview',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewDataAnalytics
@@ -2014,7 +2014,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/clinical-art-overview/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -2075,7 +2075,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{uuid}/appointment-schedule',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -2114,7 +2114,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-flow-data',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -2149,7 +2149,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/clinic-flow-provider-statistics/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -2186,7 +2186,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/clinic-lab-orders-data',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -2221,7 +2221,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{patient_uuid}/monthly-care-status',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -2255,7 +2255,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{patient_uuid}/daily-care-status',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -2297,7 +2297,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{uuid}/daily-visits',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -2336,7 +2336,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{uuid}/has-not-returned',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -2375,7 +2375,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{uuid}/monthly-appointment-schedule',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -2413,7 +2413,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{uuid}/monthly-visits',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -2452,7 +2452,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{uuid}/defaulter-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           dao.getClinicDefaulterList(request, reply);
         },
@@ -2511,7 +2511,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/custom_data/{userParams*3}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           dao.getCustomData(request, reply);
         }
@@ -2527,7 +2527,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/creation/statistics',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             roles: [privileges.canViewDataEntryStats, privileges.canViewPatient]
@@ -2567,7 +2567,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{location}/patient/creation/statistics',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             roles: [privileges.canViewDataEntryStats, privileges.canViewPatient]
@@ -2603,7 +2603,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/get-report-by-report-name',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -2737,7 +2737,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/MOH-731-report',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -2849,7 +2849,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/MOH-731-report/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -2952,7 +2952,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-status-change-tracking',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -3033,7 +3033,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-status-change-tracking/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -3097,7 +3097,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/user-cohorts',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           request.query.reportName = 'cohort-report';
@@ -3132,7 +3132,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/cohort-user/{cohortUserId}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           patientList
@@ -3158,7 +3158,7 @@ module.exports = (function () {
       method: 'DELETE',
       path: '/etl/cohort-user/{cohortUserId}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           patientList
@@ -3180,7 +3180,7 @@ module.exports = (function () {
       method: 'POST',
       path: '/etl/cohort-user/{cohortUserId}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           patientList
@@ -3208,7 +3208,7 @@ module.exports = (function () {
       method: 'POST',
       path: '/etl/cohort-user',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           patientList
@@ -3237,7 +3237,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/cohort/{cohortUuid}/cohort-users',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           patientList
@@ -3319,7 +3319,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/hiv-summary-indicators',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -3412,7 +3412,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/hiv-summary-indicators/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -3497,7 +3497,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/hiv-summary-monthly-indicators',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -3589,7 +3589,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/hiv-summary-monthly-indicators/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -3660,7 +3660,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/location/{locationUuids}/patient-by-indicator',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             roles: [privileges.canViewPatient, privileges.canViewDataAnalytics]
@@ -3707,7 +3707,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-by-indicator',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             roles: [privileges.canViewPatient, privileges.canViewDataAnalytics]
@@ -3750,7 +3750,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/data-entry-statistics/{sub}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewDataEntryStats
@@ -3853,7 +3853,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/indicators-schema',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewDataAnalytics
@@ -3886,7 +3886,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/indicators-schema-with-sections',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewDataAnalytics
@@ -3901,7 +3901,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/hiv-summary-data',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             roles: [privileges.canViewPatient, privileges.canViewDataAnalytics]
@@ -3916,7 +3916,7 @@ module.exports = (function () {
       method: 'POST',
       path: '/etl/compare-patient-lists',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           var r = request;
           var handler;
@@ -3962,7 +3962,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-list-by-indicator',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             roles: [privileges.canViewPatient, privileges.canViewDataAnalytics]
@@ -4014,7 +4014,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-lab-orders',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           if (config.eidSyncOn === true) {
             const labSyncService = new LabSyncService();
@@ -4048,7 +4048,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/sync-patient-labs',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           if (config.eidSyncOn === true) {
             const labSyncService = new LabSyncService();
@@ -4069,7 +4069,7 @@ module.exports = (function () {
       method: 'POST',
       path: '/etl/eid/order/{lab}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -4113,7 +4113,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/session/invalidate',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           dao.invalidateUserSession(request, reply);
         }
@@ -4186,7 +4186,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/eid/load-order-justifications',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           dao.loadOrderJustifications(request, reply);
         },
@@ -4199,7 +4199,7 @@ module.exports = (function () {
       method: 'POST',
       path: '/etl/fileupload',
       config: {
-        auth: 'simple',
+        auth: 'default',
         payload: {
           maxBytes: 5000000
         },
@@ -4255,7 +4255,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/files/{param*}',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: {
           directory: {
             path: config.etl.uploadsDirectory,
@@ -4269,7 +4269,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/eid/patients-with-results',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: false
         },
@@ -4296,7 +4296,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/motdNotifications',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: false
         },
@@ -4322,7 +4322,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patients-requiring-viral-load-order',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -4388,7 +4388,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-care-cascade-analysis',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewDataAnalytics
@@ -4449,7 +4449,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-care-cascade-analysis/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -4514,7 +4514,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/indicator-disaggregation-filter-options',
       config: {
-        auth: 'simple',
+        auth: 'default',
         handler: function (request, reply) {
           reply(
             require('./service/indicator-processor/indicator-filter-options.json')
@@ -4532,7 +4532,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient/{patientUuid}/medical-history-report',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewPatient
@@ -4578,7 +4578,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/departments-programs-config',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           reply(departmentProgramsService.getAllDepartmentsConfig());
@@ -4598,7 +4598,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/department-programs',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           let department = request.query.department;
@@ -4679,7 +4679,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/lab-orders-by-patient',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             roles: [
@@ -4790,7 +4790,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/radiology-diagnostic-report',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           var requestParams = request.query;
@@ -4819,7 +4819,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/radiology-images',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           var requestParams = request.query;
@@ -4846,7 +4846,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/radiology-all-patient-images',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           var requestParams = request.query;
@@ -4869,7 +4869,7 @@ module.exports = (function () {
       method: 'POST',
       path: '/etl/radiology-comments',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           var payload = request.payload;
@@ -4891,7 +4891,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/oncology-reports',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           oncologyReportsService
@@ -4918,7 +4918,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/oncology-report',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           if (request.query.reportUuid) {
@@ -4951,7 +4951,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/breast-cancer-screening-numbers',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -5009,7 +5009,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/breast-cancer-screening-numbers-patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -5050,7 +5050,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/combined-breast-cervical-cancer-screening-numbers',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -5111,7 +5111,7 @@ module.exports = (function () {
       path:
         '/etl/combined-breast-cervical-cancer-screening-numbers-patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -5153,7 +5153,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/cervical-cancer-screening-numbers',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -5212,7 +5212,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/cervical-cancer-screening-numbers-patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -5254,7 +5254,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/lung-cancer-screening-numbers',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -5312,7 +5312,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/lung-cancer-screening-numbers-patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -5353,7 +5353,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/lung-cancer-treatment-numbers',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -5412,7 +5412,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/lung-cancer-treatment-numbers-patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -5453,7 +5453,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/kibana-dashboards',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -5546,7 +5546,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-referrals-peer-navigator',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           openmrsLocationAuthorizer: {
             locationParameter: [
@@ -5700,7 +5700,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/retention-summary-report',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -5754,7 +5754,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/retention-summary-report/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           request.query.reportName = 'retention-summary-report';
@@ -5798,7 +5798,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/retention-summary-report/indicator-definitions',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {
           hapiAuthorization: {
             role: privileges.canViewClinicDashBoard
@@ -5870,7 +5870,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/hei-monthly-summary/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           request.query.reportName = 'hei-summary-patient-list';
@@ -5908,7 +5908,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-gain-loses-numbers',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           if (request.query.locationUuid) {
@@ -5949,7 +5949,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-gain-loses-patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           if (request.query.locationUuid) {
@@ -5995,7 +5995,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/patient-cervical-cancer-screening-summary',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           const patientUuid = request.query.uuid;
@@ -6014,7 +6014,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/moh-412-report',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           if (request.query.locationUuids) {
@@ -6061,7 +6061,7 @@ module.exports = (function () {
       method: 'GET',
       path: '/etl/moh-412-report/patient-list',
       config: {
-        auth: 'simple',
+        auth: 'default',
         plugins: {},
         handler: function (request, reply) {
           if (request.query.locationUuids) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2175,7 +2175,7 @@
     "@slack/client": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/@slack/client/-/client-4.12.0.tgz",
-      "integrity": "sha512-ltbdkcIWk2eIptCCT/oPmeCGlG8xb3kXfwuPTtvNujioLMo2xXqiPdfl7xK+AeUfnvj3fJLYbpTPuBTscuhgzw==",
+      "integrity": "sha1-7BTISlcs2a/tOYu89yQcWoPpTFc=",
       "requires": {
         "@types/form-data": "^2.2.1",
         "@types/is-stream": "^1.1.0",
@@ -2263,12 +2263,12 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc="
     },
     "@types/form-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz",
-      "integrity": "sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==",
+      "integrity": "sha1-UCX3QzAW+SM0hDTEAAbZp5fBsOg=",
       "requires": {
         "form-data": "*"
       }
@@ -2285,7 +2285,7 @@
     "@types/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+      "integrity": "sha1-uE17sgeiEPKvm+1DHcD76cQUO+E=",
       "requires": {
         "@types/node": "*"
       }
@@ -2342,7 +2342,7 @@
     "@types/p-cancelable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/p-cancelable/-/p-cancelable-1.0.1.tgz",
-      "integrity": "sha512-MGdhuVx7X2yJe4dgOnDQcZQAYgiC/QK1O5HUPgTMTxWYiOlyWEO5DWmPBlXQBU1F6/JM7aSgYBDrpt7kurC6dw==",
+      "integrity": "sha1-Twzoqj7gAHwnaLmz5uIq8gpu7L0=",
       "requires": {
         "p-cancelable": "*"
       }
@@ -2350,12 +2350,12 @@
     "@types/p-queue": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
-      "integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
+      "integrity": "sha1-Frxf7Oae+F768rzosT8+vjnFocg="
     },
     "@types/p-retry": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/p-retry/-/p-retry-3.0.1.tgz",
-      "integrity": "sha512-LkZCWg4JxFdQR/nGNZcMiyKAbNG3DKBRS6nn6Hg4dLS82zxkdBJJcvf4zXFvDCEI+e4dZdQX6wreqs9RDGMRfw==",
+      "integrity": "sha1-REA/QFt7YNEI34qzfY24GvHqgPI=",
       "requires": {
         "p-retry": "*"
       }
@@ -2375,7 +2375,7 @@
     "@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+      "integrity": "sha1-KzXsz87n04zXKtmSMvvVi/+zyE0="
     },
     "@types/stack-utils": {
       "version": "2.0.0",
@@ -2386,7 +2386,7 @@
     "@types/ws": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-5.1.2.tgz",
-      "integrity": "sha512-NkTXUKTYdXdnPE2aUUbGOXE1XfMK527SCvU/9bj86kyFF6kZ9ZnOQ3mK5jADn98Y2vEUD/7wKDgZa7Qst2wYOg==",
+      "integrity": "sha1-8C07HNRtt2hnNPPOg730bEnezWQ=",
       "requires": {
         "@types/events": "*",
         "@types/node": "*"
@@ -2419,7 +2419,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "accept": {
@@ -2434,7 +2434,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -2444,7 +2444,7 @@
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
@@ -2483,7 +2483,7 @@
     "agentkeepalive": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
-      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+      "integrity": "sha1-oROSTdP6JKC8O3gQjEUMKr7gD2c=",
       "requires": {
         "humanize-ms": "^1.2.1"
       }
@@ -2521,7 +2521,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -2652,7 +2652,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
@@ -2669,7 +2669,7 @@
     "array-merge-by-key": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-merge-by-key/-/array-merge-by-key-1.0.1.tgz",
-      "integrity": "sha512-LM2wZCGcDX1Ml56B02PP6vd0uelRyplz7Xx4Kf3JKsJGR4PO1K1G37MwtjzAsBjItaZh1ORFTlhN5qDIk5/R2Q=="
+      "integrity": "sha1-9UeIgdzQ0lpItZgifLSecJ2BIk4="
     },
     "array-unique": {
       "version": "0.3.2",
@@ -2685,7 +2685,7 @@
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -2710,7 +2710,7 @@
     "async": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
       "requires": {
         "lodash": "^4.17.14"
       },
@@ -2725,14 +2725,14 @@
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true,
       "optional": true
     },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+      "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2742,7 +2742,7 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "aws-sign2": {
@@ -2758,7 +2758,7 @@
     "axios": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "integrity": "sha1-/z8N4ue10YDnV62YAA8Qgbh7zqM=",
       "requires": {
         "follow-redirects": "1.5.10",
         "is-buffer": "^2.0.2"
@@ -2767,7 +2767,7 @@
     "b64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/b64/-/b64-3.0.3.tgz",
-      "integrity": "sha512-Pbeh0i6OLubPJdIdCepn8ZQHwN2MWznZHbHABSTEfQ706ie+yuxNSaPdqX1xRatT6WanaS1EazMiSg0NUW2XxQ=="
+      "integrity": "sha1-Nq/u4Nk0XwRjh85t6KZwKv5btW4="
     },
     "babel-jest": {
       "version": "26.6.3",
@@ -2943,7 +2943,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
@@ -2958,7 +2958,7 @@
         "component-emitter": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+          "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
           "dev": true
         },
         "define-property": {
@@ -2988,7 +2988,7 @@
     "bignumber.js": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+      "integrity": "sha1-gFiA+Eoym16sbny2+CdLbYK98HU="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -3000,12 +3000,12 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
     },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "requires": {
         "bytes": "3.1.0",
         "content-type": "~1.0.4",
@@ -3022,7 +3022,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -3032,7 +3032,7 @@
     "boom": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
+      "integrity": "sha1-czptlW0zsLGZnaP+bBKZaVDQF7k=",
       "requires": {
         "hoek": "6.x.x"
       },
@@ -3040,14 +3040,14 @@
         "hoek": {
           "version": "6.1.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
+          "integrity": "sha1-c7fTOVLgH+J6OLBFcpS3ndjaJCw="
         }
       }
     },
     "bourne": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/bourne/-/bourne-1.1.2.tgz",
-      "integrity": "sha512-b2dgVkTZhkQirNMohgC00rWfpVqEi9y5tKM1k3JvoNx05ODtfQoPPd4js9CYFQoY0IM8LAmnJulEuWv74zjUOg=="
+      "integrity": "sha1-4pC1vXFmY1Yy6vjvErAGstSnW4M="
     },
     "boxen": {
       "version": "4.2.0",
@@ -3154,7 +3154,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3204,7 +3204,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
     },
     "busboy": {
       "version": "0.2.14",
@@ -3231,12 +3231,12 @@
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+      "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
     },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
@@ -3253,7 +3253,7 @@
         "component-emitter": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+          "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
           "dev": true
         }
       }
@@ -3302,7 +3302,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -3326,9 +3326,9 @@
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "caniuse-lite": {
-      "version": "1.0.30001208",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+      "version": "1.0.30001300",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+      "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
       "dev": true
     },
     "capture-exit": {
@@ -3354,7 +3354,7 @@
     "catbox": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/catbox/-/catbox-7.1.5.tgz",
-      "integrity": "sha512-4fui5lELzqZ+9cnaAP/BcqXTH6LvWLBRtFhJ0I4FfgfXiSaZcf6k9m9dqOyChiTxNYtvLk7ZMYSf7ahMq3bf5A==",
+      "integrity": "sha1-xW9+jpVV0nwNwDipbvc+V9GGux8=",
       "requires": {
         "boom": "5.x.x",
         "hoek": "4.x.x",
@@ -3364,7 +3364,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -3377,12 +3377,12 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "joi": {
           "version": "10.6.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
           "requires": {
             "hoek": "4.x.x",
             "isemail": "2.x.x",
@@ -3486,7 +3486,7 @@
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -3527,7 +3527,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-data-descriptor": {
@@ -3553,7 +3553,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -3564,7 +3564,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
@@ -3773,7 +3773,7 @@
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3804,7 +3804,7 @@
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -3820,7 +3820,7 @@
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3834,7 +3834,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -3866,7 +3866,7 @@
     "content": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/content/-/content-3.0.7.tgz",
-      "integrity": "sha512-LXtnSnvE+Z1Cjpa3P9gh9kb396qV4MqpfwKy777BOSF8n6nw2vAi03tHNl0/XRqZUyzVzY/+nMXOZVnEapWzdg==",
+      "integrity": "sha1-DLuI6CcC01zPWYALit1gm7XB38I=",
       "requires": {
         "boom": "5.x.x"
       },
@@ -3874,7 +3874,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -3884,7 +3884,7 @@
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -3892,12 +3892,12 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -3982,7 +3982,7 @@
     "cron": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/cron/-/cron-1.8.2.tgz",
-      "integrity": "sha512-Gk2c4y6xKEO8FSAUTklqtfSr7oTq0CiPQeLBG5Fl0qoXpZyMcj1SG59YL+hqq04bu6/IuEA7lMkYDAplQNKkyg==",
+      "integrity": "sha1-SsXjxVuowWPYTzQHvelGMtqDcM4=",
       "requires": {
         "moment-timezone": "^0.5.x"
       }
@@ -4014,7 +4014,7 @@
     "cryptiles": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
-      "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
+      "integrity": "sha1-dppoyVYStW+q386/V6yGR5y+gyI=",
       "requires": {
         "boom": "5.x.x"
       },
@@ -4022,7 +4022,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -4071,7 +4071,7 @@
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -4114,7 +4114,7 @@
     "datatables": {
       "version": "1.10.18",
       "resolved": "https://registry.npmjs.org/datatables/-/datatables-1.10.18.tgz",
-      "integrity": "sha512-ntatMgS9NN6UMpwbmO+QkYJuKlVeMA2Mi0Gu/QxyIh+dW7ZjLSDhPT2tWlzjpIWEkDYgieDzS9Nu7bdQCW0sbQ==",
+      "integrity": "sha1-/uFugqpwsXxfrxppVKxo9ATzOnA=",
       "requires": {
         "jquery": ">=1.7"
       }
@@ -4132,7 +4132,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -4173,7 +4173,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
       "dev": true
     },
     "deep-is": {
@@ -4197,7 +4197,7 @@
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -4205,7 +4205,7 @@
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -4267,7 +4267,7 @@
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
       "requires": {
         "domelementtype": "^2.0.1",
         "entities": "^2.0.0"
@@ -4288,7 +4288,7 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8="
     },
     "domexception": {
       "version": "2.0.1",
@@ -4347,7 +4347,7 @@
     "duration": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
-      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
+      "integrity": "sha1-3fFJvDvGkBFQ/pAXER0BazNX9Sk=",
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.46"
@@ -4388,7 +4388,7 @@
     "elasticsearch": {
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-15.5.0.tgz",
-      "integrity": "sha512-ZGKKaDkOFAap61ObBNkAxhYXCcAbRfkI4NVoSeLGnTD6/cItvY2j9LII/VV8/zclGe1x5m6DsVp47E4ze4aAeQ==",
+      "integrity": "sha1-YtnyOM+eELgcUKIwOqRwwffaazc=",
       "requires": {
         "agentkeepalive": "^3.4.1",
         "chalk": "^1.0.0",
@@ -4477,7 +4477,7 @@
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -4487,7 +4487,7 @@
     "es5-ext": {
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "integrity": "sha1-k8WjrP2+8nUiCtcmRK0C7hg2jeE=",
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -4512,7 +4512,7 @@
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "integrity": "sha1-utXTwbzawoJp9MszHkMceKxwXRg=",
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -4555,7 +4555,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
     },
     "estraverse": {
       "version": "5.2.0",
@@ -4566,7 +4566,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "etag": {
@@ -4586,7 +4586,7 @@
     "eventemitter3": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+      "integrity": "sha1-LT1I+cNGaY/Og6hdfWZOmFNd9uc="
     },
     "exec-sh": {
       "version": "0.3.6",
@@ -4749,7 +4749,7 @@
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
       "requires": {
         "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
@@ -4791,7 +4791,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -4806,7 +4806,7 @@
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "integrity": "sha1-ia56BxWPedNVF4gpBDJAd+Q3kkQ=",
       "requires": {
         "type": "^2.0.0"
       },
@@ -4831,7 +4831,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -4910,7 +4910,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -4957,7 +4957,7 @@
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -4971,7 +4971,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -5066,7 +5066,7 @@
     "finity": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/finity/-/finity-0.5.4.tgz",
-      "integrity": "sha512-3l+5/1tuw616Lgb0QBimxfdd2TqaDGpfCBpfX6EqtFmqUV3FtQnVEX4Aa62DagYEqnsTIjZcTfbq9msDbXYgyA=="
+      "integrity": "sha1-8qipGY6ChkZzKOwyyL/MGaIinBE="
     },
     "flat": {
       "version": "5.0.2",
@@ -5076,7 +5076,7 @@
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
       "requires": {
         "debug": "=3.1.0"
       }
@@ -5100,7 +5100,7 @@
     "form-data": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -5134,7 +5134,7 @@
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc=",
       "dev": true
     },
     "fs.realpath": {
@@ -5151,7 +5151,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -5386,7 +5386,7 @@
     "hapi": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-16.7.0.tgz",
-      "integrity": "sha512-UeMX1LMWmHEIgMlwZGK/3lhI7X0VRvOioVply0Y9qF+/O5woGdQzNB8ZmDnLOBjnB6bdWWHyo5DEamuCsE1vmg==",
+      "integrity": "sha1-O7OVF5cd+B6BmOwEdRRV6LbLCHE=",
       "requires": {
         "accept": "2.x.x",
         "ammo": "2.x.x",
@@ -5412,7 +5412,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -5420,7 +5420,7 @@
         "isemail": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+          "integrity": "sha1-WTEKAhkxqfsGu7UeFVzgs/I2gyw=",
           "requires": {
             "punycode": "2.x.x"
           }
@@ -5428,12 +5428,12 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "joi": {
           "version": "11.4.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
-          "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
+          "integrity": "sha1-9nSJdTe2JemsPQt+FgTIKK2RPMs=",
           "requires": {
             "hoek": "4.x.x",
             "isemail": "3.x.x",
@@ -5489,7 +5489,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -5502,12 +5502,12 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "joi": {
           "version": "10.6.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
           "requires": {
             "hoek": "4.x.x",
             "isemail": "2.x.x",
@@ -5528,7 +5528,7 @@
     "hapi-cors-headers": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hapi-cors-headers/-/hapi-cors-headers-1.0.3.tgz",
-      "integrity": "sha512-U/y+kpVLUJ0y86fEk8yleou9C1T5wFopcWQjuxKdMXzCcymTjfSqGz59waqvngUs1SbeXav/y8Ga9C0G0L1MGg=="
+      "integrity": "sha1-hWsKmHD0NSSUksWlLSdEMXqMwf0="
     },
     "hapi-routes": {
       "version": "3.0.0",
@@ -5563,7 +5563,7 @@
             "hoek": {
               "version": "4.2.1",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+              "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
             }
           }
         },
@@ -5599,7 +5599,7 @@
             "hoek": {
               "version": "4.2.1",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+              "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
             }
           }
         }
@@ -5622,7 +5622,7 @@
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5670,7 +5670,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-number": {
@@ -5728,7 +5728,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -5741,12 +5741,12 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "joi": {
           "version": "10.6.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
           "requires": {
             "hoek": "4.x.x",
             "isemail": "2.x.x",
@@ -5767,7 +5767,7 @@
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -5833,7 +5833,7 @@
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -5973,7 +5973,7 @@
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -6082,7 +6082,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
       "version": "1.3.5",
@@ -6093,7 +6093,7 @@
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+      "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM="
     },
     "iron": {
       "version": "4.0.5",
@@ -6108,7 +6108,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -6118,7 +6118,7 @@
     "is-accessor-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
       "requires": {
         "kind-of": "^6.0.0"
       }
@@ -6170,7 +6170,7 @@
     "is-data-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
       "requires": {
         "kind-of": "^6.0.0"
       }
@@ -6178,12 +6178,12 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+      "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4="
     },
     "is-descriptor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
       "requires": {
         "is-accessor-descriptor": "^1.0.0",
         "is-data-descriptor": "^1.0.0",
@@ -6268,7 +6268,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -6335,7 +6335,7 @@
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -6348,7 +6348,7 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "is-wsl": {
@@ -7809,7 +7809,7 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "topo": {
           "version": "2.0.2",
@@ -7941,7 +7941,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -7951,7 +7951,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -8039,7 +8039,7 @@
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0="
     },
     "kleur": {
       "version": "3.0.3",
@@ -8436,7 +8436,7 @@
     "log": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log/-/log-6.0.0.tgz",
-      "integrity": "sha512-sxChESNYJ/EcQv8C7xpmxhtTOngoXuMEqGDAkhXBEmt3MAzM3SM/TmIBOqnMEVdrOv1+VgZoYbo6U2GemQiU4g==",
+      "integrity": "sha1-Ho5lXwOJFI5ynZ3dbTvL6Lk7jSE=",
       "requires": {
         "d": "^1.0.0",
         "duration": "^0.2.2",
@@ -8559,7 +8559,7 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
       "dev": true
     },
     "lru-cache": {
@@ -8689,7 +8689,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -8702,7 +8702,7 @@
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -8712,7 +8712,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -8905,7 +8905,7 @@
     "multer": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.2.tgz",
-      "integrity": "sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==",
+      "integrity": "sha1-Lx9NEtuu66dMs35iPyNL9NPSBXo=",
       "requires": {
         "append-field": "^1.0.0",
         "busboy": "^0.2.11",
@@ -8920,7 +8920,7 @@
     "mysql": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+      "integrity": "sha1-IlQUOFXFqMc4JeRSK68uoCF2Zxc=",
       "requires": {
         "bignumber.js": "9.0.0",
         "readable-stream": "2.3.7",
@@ -8936,7 +8936,7 @@
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -8950,7 +8950,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -8965,7 +8965,7 @@
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -9004,7 +9004,7 @@
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+      "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs="
     },
     "neo-async": {
       "version": "2.6.1",
@@ -9014,7 +9014,7 @@
     "nes": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/nes/-/nes-6.5.2.tgz",
-      "integrity": "sha512-Zb8Wqgrhefl8JzXGZ//RY2FGdpGiywHSyCazfj+o6VANZul86UDDGX6qZm+36RKlipKlODCA+Ij1Yxz9l2LhvQ==",
+      "integrity": "sha1-2HOfdxBkkUkcQVjDQW9ewCjyyjo=",
       "requires": {
         "boom": "4.x.x",
         "call": "3.x.x",
@@ -9051,12 +9051,12 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "joi": {
           "version": "10.6.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
           "requires": {
             "hoek": "4.x.x",
             "isemail": "2.x.x",
@@ -9075,7 +9075,7 @@
         "ws": {
           "version": "3.3.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
           "requires": {
             "async-limiter": "~1.0.0",
             "safe-buffer": "~5.1.0",
@@ -9106,7 +9106,7 @@
     "nigel": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.4.tgz",
-      "integrity": "sha512-3SZCCS/duVDGxFpTROHEieC+itDo4UqL9JNUyQJv3rljudQbK6aqus5B4470OxhESPJLN93Qqxg16rH7DUjbfQ==",
+      "integrity": "sha1-7c2C8uk4f+NLoh4xJ65IkVR8eUU=",
       "requires": {
         "hoek": "6.x.x",
         "vise": "3.x.x"
@@ -9115,12 +9115,12 @@
         "hoek": {
           "version": "6.1.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
+          "integrity": "sha1-c7fTOVLgH+J6OLBFcpS3ndjaJCw="
         },
         "vise": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.2.tgz",
-          "integrity": "sha512-X52VtdRQbSBXdjcazRiY3eRgV3vTQ0B+7Wh8uC9cVv7lKfML5m9+9NHlbcgCY0R9EAqD1v/v7o9mhGh2A3ANFg==",
+          "integrity": "sha1-mot0UPeDqndvqjJ/5H17/dsicmY=",
           "requires": {
             "hoek": "6.x.x"
           }
@@ -9130,7 +9130,7 @@
     "node-cache": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
+      "integrity": "sha1-79hHTe5O3sQTjN3tWA9VFlAPczQ=",
       "requires": {
         "clone": "2.x",
         "lodash": "^4.17.15"
@@ -9146,7 +9146,7 @@
     "node-cron": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-2.0.3.tgz",
-      "integrity": "sha512-eJI+QitXlwcgiZwNNSRbqsjeZMp5shyajMR81RZCqeW0ZDEj4zU9tpd4nTh/1JsBiKbF8d08FCewiipDmVIYjg==",
+      "integrity": "sha1-uWSXhNDWwAdYQQ7vIvpUoQ4/YC0=",
       "requires": {
         "opencollective-postinstall": "^2.0.0",
         "tz-offset": "0.0.1"
@@ -9227,7 +9227,7 @@
     "nodemailer": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.7.0.tgz",
-      "integrity": "sha512-IludxDypFpYw4xpzKdMAozBSkzKHmNBvGanUREjJItgJ2NYcK/s8+PggVhj7c2yGFQykKsnnmv1+Aqo0ZfjHmw=="
+      "integrity": "sha1-RCDgar//130GGPGE6kkEfbhPStg="
     },
     "nodemon": {
       "version": "2.0.4",
@@ -11671,7 +11671,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -11710,7 +11710,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-data-descriptor": {
@@ -11725,7 +11725,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -11736,7 +11736,7 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
               "dev": true
             }
           }
@@ -11760,7 +11760,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -11870,7 +11870,7 @@
     "p-cancelable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.0.0.tgz",
-      "integrity": "sha512-USgPoaC6tkTGlS831CxsVdmZmyb8tR1D+hStI84MyckLOzfJlYQUweomrwE3D8T7u5u5GVuW064LT501wHTYYA=="
+      "integrity": "sha1-B+nG0iwx+cZ4TLTx4UVKebbZ4tY="
     },
     "p-each-series": {
       "version": "2.2.0",
@@ -11914,12 +11914,12 @@
     "p-queue": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
-      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+      "integrity": "sha1-A2CYJmgrdDvpoi26JQUb1Gck/DQ="
     },
     "p-retry": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
-      "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+      "integrity": "sha1-MWtMiJPiyNwc+okfQGxLQivr8yg=",
       "requires": {
         "retry": "^0.12.0"
       }
@@ -11986,7 +11986,7 @@
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -12054,7 +12054,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -12111,7 +12111,7 @@
     "podium": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/podium/-/podium-1.3.0.tgz",
-      "integrity": "sha512-ZIujqk1pv8bRZNVxwwwq0BhXilZ2udycQT3Kp8ah3f3TcTmVg7ILJsv/oLf47gRa2qeiP584lNq+pfvS9U3aow==",
+      "integrity": "sha1-PEkPVNFvEPUmDL6YZB8ctzOohRw=",
       "requires": {
         "hoek": "4.x.x",
         "items": "2.x.x",
@@ -12126,12 +12126,12 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "joi": {
           "version": "10.6.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
           "requires": {
             "hoek": "4.x.x",
             "isemail": "2.x.x",
@@ -12201,12 +12201,12 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
     },
     "promise-mysql": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/promise-mysql/-/promise-mysql-3.3.2.tgz",
-      "integrity": "sha512-b0Ew/FB33JXKdIEtExs9GuPTtTD29ABrIMSJlzakSL8AuiM+yLXIshc9lOY28+M3bNNXGNPllTWM/gDQ9FM+7g==",
+      "integrity": "sha1-yY3HV5Tax/i5Sj5RgIpPY5hKTdg=",
       "requires": {
         "@types/bluebird": "^3.5.26",
         "@types/mysql": "^2.15.2",
@@ -12227,7 +12227,7 @@
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "integrity": "sha1-/cIzZQVEfT8vLGOO0nLK9hS7sr8=",
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
@@ -12257,7 +12257,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "pupa": {
       "version": "2.0.1",
@@ -12276,7 +12276,7 @@
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -12289,12 +12289,12 @@
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+      "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE="
     },
     "raw-body": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
       "requires": {
         "bytes": "3.1.0",
         "http-errors": "1.7.2",
@@ -12305,7 +12305,7 @@
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
@@ -12693,7 +12693,7 @@
     "redis": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "integrity": "sha1-ICKI4/WMSfYHnZevehDhMDrhSwI=",
       "requires": {
         "double-ended-queue": "^2.1.0-0",
         "redis-commands": "^1.2.0",
@@ -12743,7 +12743,7 @@
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -12826,7 +12826,7 @@
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -12853,12 +12853,12 @@
         "extend": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+          "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
         },
         "form-data": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -12868,7 +12868,7 @@
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
         }
       }
     },
@@ -12985,7 +12985,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
     "retry": {
@@ -13055,7 +13055,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "sane": {
       "version": "4.1.0",
@@ -13212,7 +13212,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
       "dev": true
     },
     "semver-compare": {
@@ -13247,7 +13247,7 @@
     "send": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -13267,7 +13267,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           },
@@ -13282,12 +13282,12 @@
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+          "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
         },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
         }
       }
     },
@@ -13302,7 +13302,7 @@
     "serve-static": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -13324,7 +13324,7 @@
     "set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -13347,7 +13347,7 @@
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -13398,12 +13398,12 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "joi": {
           "version": "10.6.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
           "requires": {
             "hoek": "4.x.x",
             "isemail": "2.x.x",
@@ -13480,7 +13480,7 @@
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
         "base": "^0.11.1",
@@ -13496,7 +13496,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -13543,7 +13543,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-data-descriptor": {
@@ -13569,7 +13569,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -13580,7 +13580,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         },
         "source-map": {
@@ -13594,7 +13594,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
         "define-property": "^1.0.0",
@@ -13616,7 +13616,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
@@ -13625,7 +13625,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "kind-of": {
@@ -13642,7 +13642,7 @@
     "somever": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/somever/-/somever-1.0.1.tgz",
-      "integrity": "sha512-PCDMBcega4n7wuBUKmkiXidF3cOwtHHGg2qJYl0Rkw7StZqORoCgqce7HUuWNta/NAiQhwLDezNnTANxEWPCGA==",
+      "integrity": "sha1-KKXH3g1V94GvUvvOmWDbG4TOIG4=",
       "requires": {
         "hoek": "4.x.x"
       }
@@ -13650,12 +13650,12 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
     },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "dev": true,
       "requires": {
         "atob": "^2.1.2",
@@ -13716,7 +13716,7 @@
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -13730,7 +13730,7 @@
     "sprintf-kit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.0.tgz",
-      "integrity": "sha512-/0d2YTn8ZFVpIPAU230S9ZLF8WDkSSRWvh/UOLM7zzvkCchum1TtouRgyV8OfgOaYilSGU4lSSqzwBXJVlAwUw==",
+      "integrity": "sha1-R0mdY26cxo8vkh0w608LkRoteDU=",
       "requires": {
         "es5-ext": "^0.10.46"
       }
@@ -13748,7 +13748,7 @@
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -13786,7 +13786,7 @@
     "statehood": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/statehood/-/statehood-5.0.4.tgz",
-      "integrity": "sha512-6/feFLqqHylvA/dHwJA0DgXvbEcKgbhRUeljsuu6+cIr8PO88nax7Wc+celZlPTncqT2arsxXL8P329Q1yfe9Q==",
+      "integrity": "sha1-u1w0PDV+O2oYJgw2zeSiglY8pVg=",
       "requires": {
         "boom": "5.x.x",
         "bourne": "1.x.x",
@@ -13800,7 +13800,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -13808,7 +13808,7 @@
         "isemail": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-          "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+          "integrity": "sha1-WTEKAhkxqfsGu7UeFVzgs/I2gyw=",
           "requires": {
             "punycode": "2.x.x"
           }
@@ -13816,12 +13816,12 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "joi": {
           "version": "12.0.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
-          "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
+          "integrity": "sha1-RvVeaPTZYo8Bu7aVkCyLMHrY0zo=",
           "requires": {
             "hoek": "4.x.x",
             "isemail": "3.x.x",
@@ -13880,7 +13880,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-data-descriptor": {
@@ -13906,7 +13906,7 @@
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
           "dev": true,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -13917,7 +13917,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
       }
@@ -14071,7 +14071,7 @@
     "subtext": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/subtext/-/subtext-5.0.1.tgz",
-      "integrity": "sha512-zH/jaUKJ/bkrTpEe3zuTFIRnqAwv5xcGpXA2JaxEc30KRAT4k78jZnRqM45snjBSZAuvpI8chRUh1VZprcUVfw==",
+      "integrity": "sha1-O6OckyYOLi7h7dzeNxvp1fvoiGE=",
       "requires": {
         "boom": "5.x.x",
         "bourne": "1.x.x",
@@ -14084,7 +14084,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.x.x"
           }
@@ -14092,7 +14092,7 @@
         "wreck": {
           "version": "12.5.1",
           "resolved": "https://registry.npmjs.org/wreck/-/wreck-12.5.1.tgz",
-          "integrity": "sha512-l5DUGrc+yDyIflpty1x9XuMj1ehVjC/dTbF3/BasOO77xk0EdEa4M/DuOY8W88MQDAD0fEDqyjc8bkIMHd2E9A==",
+          "integrity": "sha1-zS/84WdEnh8CQu2c+AVS4g+2kCo=",
           "requires": {
             "boom": "5.x.x",
             "hoek": "4.x.x"
@@ -14269,7 +14269,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "kind-of": {
@@ -14292,7 +14292,7 @@
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
         "define-property": "^2.0.2",
@@ -14356,7 +14356,7 @@
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
     },
     "topo": {
       "version": "1.1.0",
@@ -14376,7 +14376,7 @@
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
       "dev": true,
       "requires": {
         "nopt": "~1.0.10"
@@ -14385,7 +14385,7 @@
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -14426,7 +14426,7 @@
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+      "integrity": "sha1-hI3XaY2vo+VKbEeedZxLw/GIR6A="
     },
     "type-check": {
       "version": "0.3.2",
@@ -14446,7 +14446,7 @@
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -14469,7 +14469,7 @@
     "tz-offset": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tz-offset/-/tz-offset-0.0.1.tgz",
-      "integrity": "sha512-kMBmblijHJXyOpKzgDhKx9INYU4u4E1RPMB0HqmKSgWG8vEcf3exEfLh4FFfzd3xdQOw9EuIy/cP0akY6rHopQ=="
+      "integrity": "sha1-/vkgJXAk01g+2QcqdnchoYvbinY="
     },
     "uglify-js": {
       "version": "3.8.0",
@@ -14492,12 +14492,12 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw="
     },
     "undefsafe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.3.tgz",
-      "integrity": "sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==",
+      "integrity": "sha1-axZucJStRjE7IgLafsws18xueq4=",
       "dev": true,
       "requires": {
         "debug": "^2.2.0"
@@ -14506,7 +14506,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -14522,7 +14522,7 @@
     "underscore.string": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
-      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "integrity": "sha1-/CrSVbi9MJ4jnLxYFv0jqbfqQCM=",
       "requires": {
         "sprintf-js": "^1.0.3",
         "util-deprecate": "^1.0.2"
@@ -14559,7 +14559,7 @@
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
@@ -14738,7 +14738,7 @@
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
     "util-deprecate": {
@@ -14754,7 +14754,7 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
     },
     "v8-to-istanbul": {
       "version": "7.1.1",
@@ -14844,12 +14844,12 @@
         "items": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/items/-/items-2.1.2.tgz",
-          "integrity": "sha512-kezcEqgB97BGeZZYtX/MA8AG410ptURstvnz5RAgyFZ8wQFPMxHY8GpTq+/ZHKT3frSlIthUq7EvLt9xn3TvXg=="
+          "integrity": "sha1-CEk1RZWAXVhtrJjn5uhVVuqDhVg="
         },
         "joi": {
           "version": "10.6.0",
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
           "requires": {
             "hoek": "4.x.x",
             "isemail": "2.x.x",
@@ -14888,7 +14888,7 @@
     "walk": {
       "version": "2.3.14",
       "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
-      "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
+      "integrity": "sha1-YOyGMc/SMnauHnNjzhHWJkUuHvM=",
       "requires": {
         "foreachasync": "^3.0.0"
       }
@@ -15179,7 +15179,7 @@
     "ws": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "integrity": "sha1-3/7xSGa46NyRM1glFNG++vlumA8=",
       "requires": {
         "async-limiter": "~1.0.0"
       }
@@ -15205,7 +15205,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
     },
     "y18n": {
       "version": "4.0.0",
@@ -15282,7 +15282,7 @@
     "yargs-parser": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "integrity": "sha1-cgImW4n36eny5XZeD+c1qQXtuqg=",
       "requires": {
         "camelcase": "^4.1.0"
       }


### PR DESCRIPTION
This PR does the following:
- Refactors the current authentication mechanism(basic auth) to use cookie-based. The idea is to extract `session cookie` from the request headers, use it to authenticate against openmrs rest.