### PR TITLE
Add columns to daily schedule to show sms delivery status

### DIFF
--- a/app/reporting-framework/json-reports/patient-list-schedules-template.json
+++ b/app/reporting-framework/json-reports/patient-list-schedules-template.json
@@ -81,6 +81,14 @@
       }
     },
     {
+      "table": "etl.sms_delivery_report",
+      "alias": "delivery_report",
+      "join": {
+        "type": "LEFT",
+        "joinCondition": "delivery_report.person_id = t2.person_id and DATE_FORMAT(delivery_report.date_created, '%Y-%m-%d')='{startDate}'"
+      }
+    },
+    {
       "table": "etl.flat_hiv_summary_v15b",
       "alias": "tb",
       "join": {
@@ -249,6 +257,11 @@
       "type": "simple_column",
       "alias": "sms_receive_time",
       "column": "consent.sms_receive_time"
+    },
+    {
+      "type": "simple_column",
+      "alias": "sms_delivery_status",
+      "column": "delivery_report.delivery_status"
     },
     {
       "type": "simple_column",

--- a/app/reporting-framework/json-reports/patient-list-template.json
+++ b/app/reporting-framework/json-reports/patient-list-template.json
@@ -87,6 +87,14 @@
         "type": "LEFT",
         "joinCondition": "cs.person_id = t1.person_id AND cs.next_clinical_datetime_cervical_cancer_screening IS NULL"
       }
+    },
+    {
+      "table": "etl.sms_delivery_report",
+      "alias": "delivery_report",
+      "join": {
+        "type": "LEFT",
+        "joinCondition": "delivery_report.person_id = t1.person_id and DATE_FORMAT(delivery_report.date_created, '%Y-%m-%d')='{startDate}'"
+      }
     }
   ],
   "columns": [
@@ -236,6 +244,11 @@
       "type": "simple_column",
       "alias": "sms_receive_time",
       "column": "consent.sms_receive_time"
+    },
+    {
+      "type": "derived_column",
+      "alias": "sms_delivery_status",
+      "column": "delivery_report.delivery_status"
     },
     {
       "type": "simple_column",

--- a/app/reporting-framework/json-reports/patient-list-with-contacts-template.json
+++ b/app/reporting-framework/json-reports/patient-list-with-contacts-template.json
@@ -87,6 +87,14 @@
         "type": "LEFT",
         "joinCondition": "cs.person_id = t1.person_id AND cs.next_clinical_datetime_cervical_cancer_screening IS NULL"
       }
+    },
+    {
+      "table": "etl.sms_delivery_report",
+      "alias": "delivery_report",
+      "join": {
+        "type": "LEFT",
+        "joinCondition": "delivery_report.person_id = t1.person_id and DATE_FORMAT(delivery_report.date_created, '%Y-%m-%d')='{startDate}'"
+      }
     }
   ],
   "columns": [
@@ -236,6 +244,11 @@
       "type": "simple_column",
       "alias": "sms_receive_time",
       "column": "consent.sms_receive_time"
+    },
+    {
+      "type": "simple_column",
+      "alias": "sms_delivery_status",
+      "column": "delivery_report.delivery_status"
     },
     {
       "type": "simple_column",


### PR DESCRIPTION
Add columns to daily schedule patient list to show sms delivery status for patients who consented to receive sms